### PR TITLE
feat: store rendered videos in R2 with presigned playback URLs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,9 +49,14 @@ EXA_API_KEY=
 DAYTONA_API_KEY=
 # Optional region/target (e.g. us, eu).
 # DAYTONA_TARGET=
-# Public base URL of THIS api, used to build absolute URLs for rendered videos
-# the web embeds. Defaults to http://localhost:8787 in dev.
-# API_PUBLIC_URL=http://localhost:8787
+
+# Cloudflare R2 (S3-compatible) — stores rendered videos; the web streams them
+# via short-lived presigned URLs. All four are required.
+# Dashboard: Cloudflare > R2 > (bucket) and "Manage R2 API Tokens".
+R2_ACCOUNT_ID=
+R2_ACCESS_KEY_ID=
+R2_SECRET_ACCESS_KEY=
+R2_BUCKET=animus-videos
 
 # Email (magic link) — https://resend.com/api-keys
 # Without a key, magic links are printed to the API console.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,9 +81,11 @@ Cross-package "does it compile" = `bun run typecheck`.
 **Roadmap:** shell ✓ (settings backend; conversation persistence with generated
 titles; sidebar list/search/rename/delete) → streaming chat ✓ (`/api/chat` →
 `useChat` + Streamdown, real agent loop with HITL + Exa web-research tools) →
-**next:** first Manim scene end-to-end via Daytona → generalize the
-render/repair loop + narration + R2 + playback → later: quota/billing,
-autonomous mode. (Outstanding before the chat phase fully closes: HTTP-level
+first Manim scene end-to-end via Daytona ✓ → R2 video storage ✓ (rendered mp4s
+live in R2; the agent's renderScene returns an object key, the web streams via
+short-lived presigned URLs minted by `/api/media/sign`, and a conversation's
+objects are deleted with it) → **next:** generalize the render/repair loop +
+narration + playback polish → later: quota/billing, autonomous mode. (Outstanding before the chat phase fully closes: HTTP-level
 route tests for `conversations` + the `/api/chat` sync contract, and an atomic
 title-generation claim.)
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -14,6 +14,8 @@
     "@animus/auth": "workspace:*",
     "@animus/core": "workspace:*",
     "@animus/db": "workspace:*",
+    "@aws-sdk/client-s3": "^3.1075.0",
+    "@aws-sdk/s3-request-presigner": "^3.1075.0",
     "ai": "^6.0.206",
     "hono": "^4.12.25",
     "pino": "^10.3.1",

--- a/apps/api/src/__tests__/media.lib.test.ts
+++ b/apps/api/src/__tests__/media.lib.test.ts
@@ -1,0 +1,163 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { send, getSignedUrl } = vi.hoisted(() => ({
+  send: vi.fn(),
+  getSignedUrl: vi.fn(),
+}));
+
+vi.mock("@animus/core/env", () => ({
+  getServerEnv: () => ({
+    r2AccountId: "acct",
+    r2AccessKeyId: "akid",
+    r2SecretAccessKey: "secret",
+    r2Bucket: "animus-videos",
+  }),
+}));
+
+vi.mock("@aws-sdk/client-s3", () => {
+  class FakeCommand {
+    input: unknown;
+    constructor(input: unknown) {
+      this.input = input;
+    }
+  }
+  return {
+    S3Client: class {
+      send = send;
+    },
+    PutObjectCommand: class extends FakeCommand {},
+    GetObjectCommand: class extends FakeCommand {},
+    ListObjectsV2Command: class extends FakeCommand {},
+    DeleteObjectsCommand: class extends FakeCommand {},
+  };
+});
+
+vi.mock("@aws-sdk/s3-request-presigner", () => ({ getSignedUrl }));
+
+const {
+  deleteConversationMedia,
+  mediaKeyConversationId,
+  saveVideo,
+  signMediaUrl,
+} = await import("../lib/media.ts");
+
+const KEY_SHAPE = /^videos\/conv1\/Scene-[a-f0-9]{8}\.mp4$/;
+
+beforeEach(() => {
+  send.mockReset();
+  getSignedUrl.mockReset();
+});
+
+describe("saveVideo", () => {
+  it("uploads to a conversation-scoped, unique mp4 key and returns it", async () => {
+    send.mockResolvedValue({});
+    const key = await saveVideo({
+      bytes: new Uint8Array([1, 2, 3]),
+      conversationId: "conv1",
+      scene: "Scene",
+    });
+
+    expect(key).toMatch(KEY_SHAPE);
+    const command = send.mock.calls[0]?.[0];
+    expect(command.input).toMatchObject({
+      Bucket: "animus-videos",
+      Key: key,
+      ContentType: "video/mp4",
+    });
+  });
+
+  it("sanitizes unsafe characters in the conversation id and scene", async () => {
+    send.mockResolvedValue({});
+    const key = await saveVideo({
+      bytes: new Uint8Array(),
+      conversationId: "../evil",
+      scene: "a/b c",
+    });
+    // No traversal or spaces survive into the key (../ -> ___).
+    expect(key.startsWith("videos/___evil/")).toBe(true);
+    expect(key).not.toContain("..");
+    expect(key).not.toContain(" ");
+  });
+});
+
+describe("mediaKeyConversationId", () => {
+  it("extracts the conversation id from a well-formed key", () => {
+    expect(mediaKeyConversationId("videos/conv1/Scene-ab12cd34.mp4")).toBe(
+      "conv1"
+    );
+  });
+
+  it("rejects malformed keys and traversal", () => {
+    expect(mediaKeyConversationId("videos/conv1/scene.txt")).toBeNull();
+    expect(mediaKeyConversationId("../../etc/passwd")).toBeNull();
+    expect(mediaKeyConversationId("videos/conv1/../x.mp4")).toBeNull();
+  });
+});
+
+describe("signMediaUrl", () => {
+  it("delegates to getSignedUrl for the key", async () => {
+    getSignedUrl.mockResolvedValue("https://signed/url");
+    const url = await signMediaUrl("videos/conv1/Scene-ab12cd34.mp4");
+
+    expect(url).toBe("https://signed/url");
+    const command = getSignedUrl.mock.calls[0]?.[1];
+    expect(command.input).toMatchObject({
+      Bucket: "animus-videos",
+      Key: "videos/conv1/Scene-ab12cd34.mp4",
+    });
+  });
+});
+
+describe("deleteConversationMedia", () => {
+  it("lists by prefix and deletes the found objects", async () => {
+    send
+      .mockResolvedValueOnce({
+        Contents: [
+          { Key: "videos/conv1/a.mp4" },
+          { Key: "videos/conv1/b.mp4" },
+        ],
+        IsTruncated: false,
+      })
+      .mockResolvedValueOnce({});
+
+    await deleteConversationMedia("conv1");
+
+    expect(send).toHaveBeenCalledTimes(2);
+    expect(send.mock.calls[0]?.[0].input).toMatchObject({
+      Bucket: "animus-videos",
+      Prefix: "videos/conv1/",
+    });
+    expect(send.mock.calls[1]?.[0].input.Delete.Objects).toEqual([
+      { Key: "videos/conv1/a.mp4" },
+      { Key: "videos/conv1/b.mp4" },
+    ]);
+  });
+
+  it("paginates through truncated listings", async () => {
+    send
+      .mockResolvedValueOnce({
+        Contents: [{ Key: "videos/conv1/a.mp4" }],
+        IsTruncated: true,
+        NextContinuationToken: "tok",
+      })
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({
+        Contents: [{ Key: "videos/conv1/b.mp4" }],
+        IsTruncated: false,
+      })
+      .mockResolvedValueOnce({});
+
+    await deleteConversationMedia("conv1");
+
+    expect(send).toHaveBeenCalledTimes(4);
+    expect(send.mock.calls[2]?.[0].input.ContinuationToken).toBe("tok");
+  });
+
+  it("does not issue a delete when nothing matches", async () => {
+    send.mockResolvedValueOnce({ Contents: [], IsTruncated: false });
+
+    await deleteConversationMedia("conv1");
+
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/__tests__/media.route.test.ts
+++ b/apps/api/src/__tests__/media.route.test.ts
@@ -1,0 +1,75 @@
+import { Hono } from "hono";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mediaKeyConversationId, signMediaUrl, userOwnsConversation } =
+  vi.hoisted(() => ({
+    mediaKeyConversationId: vi.fn(),
+    signMediaUrl: vi.fn(),
+    userOwnsConversation: vi.fn(),
+  }));
+
+vi.mock("../lib/media.ts", () => ({ mediaKeyConversationId, signMediaUrl }));
+vi.mock("../services/conversations.ts", () => ({ userOwnsConversation }));
+// Bypass the real session resolution; the wrapper app injects the user instead.
+vi.mock("../middleware/auth.ts", () => ({
+  requireAuth: (_c: unknown, next: () => Promise<void>) => next(),
+}));
+
+const { mediaRoute } = await import("../routes/media.ts");
+
+type TestUser = { id: string } | null;
+
+function appWith(user: TestUser) {
+  const app = new Hono<{ Variables: { user: TestUser } }>();
+  app.use("*", async (c, next) => {
+    c.set("user", user);
+    await next();
+  });
+  app.route("/media", mediaRoute);
+  return app;
+}
+
+beforeEach(() => {
+  mediaKeyConversationId.mockReset();
+  signMediaUrl.mockReset();
+  userOwnsConversation.mockReset();
+});
+
+describe("GET /media/sign", () => {
+  it("400s when the key is missing or malformed", async () => {
+    mediaKeyConversationId.mockReturnValue(null);
+    const res = await appWith({ id: "u1" }).request("/media/sign?key=bad");
+
+    expect(res.status).toBe(400);
+    expect(signMediaUrl).not.toHaveBeenCalled();
+  });
+
+  it("404s when the caller does not own the conversation", async () => {
+    mediaKeyConversationId.mockReturnValue("conv1");
+    userOwnsConversation.mockResolvedValue(false);
+
+    const res = await appWith({ id: "u1" }).request(
+      "/media/sign?key=videos/conv1/Scene-ab12cd34.mp4"
+    );
+
+    expect(res.status).toBe(404);
+    expect(signMediaUrl).not.toHaveBeenCalled();
+  });
+
+  it("returns a presigned url for an owned conversation", async () => {
+    mediaKeyConversationId.mockReturnValue("conv1");
+    userOwnsConversation.mockResolvedValue(true);
+    signMediaUrl.mockResolvedValue("https://signed/url");
+
+    const res = await appWith({ id: "u1" }).request(
+      "/media/sign?key=videos/conv1/Scene-ab12cd34.mp4"
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ url: "https://signed/url" });
+    expect(userOwnsConversation).toHaveBeenCalledWith({
+      conversationId: "conv1",
+      userId: "u1",
+    });
+  });
+});

--- a/apps/api/src/lib/media.ts
+++ b/apps/api/src/lib/media.ts
@@ -1,37 +1,123 @@
-/** v0.1 media storage: rendered videos are written to a local directory and
- * served back by the media route. This is the `SaveVideo` the agent's renderScene
- * tool calls. The seam is deliberate — swapping this for Cloudflare R2 later is a
- * single-file change that doesn't touch the agent or its tools. */
+/** Media storage on Cloudflare R2 (S3-compatible). Rendered videos are uploaded
+ * here by the agent's renderScene tool; the browser streams them straight from
+ * R2 via short-lived presigned URLs minted by the media route. The renderScene
+ * output stores only the object KEY, so a saved conversation keeps working on
+ * replay (we re-sign on demand rather than baking an expiring URL into it). */
 
-import { mkdir, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 import { getServerEnv } from "@animus/core/env";
+import {
+  DeleteObjectsCommand,
+  GetObjectCommand,
+  ListObjectsV2Command,
+  PutObjectCommand,
+  S3Client,
+} from "@aws-sdk/client-s3";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 
-const MEDIA_ROOT = join(tmpdir(), "animus-media");
+/** How long a presigned playback URL is valid. The web re-signs on load, so a
+ * window comfortably longer than a viewing session is plenty. */
+const SIGNED_URL_TTL_SEC = 3600;
+/** R2 delete-objects accepts up to 1000 keys per request. */
+const DELETE_BATCH = 1000;
 const UNSAFE_NAME_CHARS = /[^a-zA-Z0-9_-]/g;
-const TRAILING_SLASH = /\/$/;
+const MEDIA_PREFIX = "videos";
+/** videos/<conversationId>/<file>.mp4 — pins the shape we mint and accept. */
+const MEDIA_KEY = /^videos\/([a-zA-Z0-9_-]+)\/[a-zA-Z0-9_-]+\.mp4$/;
 
-export function mediaRoot(): string {
-  return MEDIA_ROOT;
+let client: S3Client | null = null;
+
+function getClient(): S3Client {
+  if (!client) {
+    const env = getServerEnv();
+    client = new S3Client({
+      region: "auto",
+      endpoint: `https://${env.r2AccountId}.r2.cloudflarestorage.com`,
+      credentials: {
+        accessKeyId: env.r2AccessKeyId,
+        secretAccessKey: env.r2SecretAccessKey,
+      },
+    });
+  }
+  return client;
+}
+
+function bucket(): string {
+  return getServerEnv().r2Bucket;
 }
 
 function safeName(value: string): string {
   return value.replace(UNSAFE_NAME_CHARS, "_").slice(0, 60) || "scene";
 }
 
-/** Persist a rendered mp4 and return an absolute URL the web can embed. */
+/** The object key prefix for a conversation's media — scopes listing/deletion. */
+function conversationPrefix(conversationId: string): string {
+  return `${MEDIA_PREFIX}/${safeName(conversationId)}/`;
+}
+
+/** The conversation id a well-formed media key belongs to, or null if malformed. */
+export function mediaKeyConversationId(key: string): string | null {
+  return key.match(MEDIA_KEY)?.[1] ?? null;
+}
+
+/** Persist a rendered mp4 to R2 and return its object key (NOT a URL). */
 export async function saveVideo(input: {
   bytes: Uint8Array;
   conversationId: string;
   scene: string;
 }): Promise<string> {
-  const conversationId = safeName(input.conversationId);
   const file = `${safeName(input.scene)}-${crypto.randomUUID().slice(0, 8)}.mp4`;
-  const dir = join(MEDIA_ROOT, conversationId);
-  await mkdir(dir, { recursive: true });
-  await writeFile(join(dir, file), input.bytes);
+  const key = `${conversationPrefix(input.conversationId)}${file}`;
+  await getClient().send(
+    new PutObjectCommand({
+      Bucket: bucket(),
+      Key: key,
+      Body: input.bytes,
+      ContentType: "video/mp4",
+    })
+  );
+  return key;
+}
 
-  const base = getServerEnv().apiPublicUrl.replace(TRAILING_SLASH, "");
-  return `${base}/api/media/${conversationId}/${file}`;
+/** Mint a short-lived presigned GET URL the browser can stream from directly. */
+export function signMediaUrl(key: string): Promise<string> {
+  return getSignedUrl(
+    getClient(),
+    new GetObjectCommand({ Bucket: bucket(), Key: key }),
+    { expiresIn: SIGNED_URL_TTL_SEC }
+  );
+}
+
+/** Delete every object stored for a conversation (best-effort, paginated). */
+export async function deleteConversationMedia(
+  conversationId: string
+): Promise<void> {
+  const s3 = getClient();
+  const Bucket = bucket();
+  const Prefix = conversationPrefix(conversationId);
+  let continuationToken: string | undefined;
+
+  do {
+    const listed = await s3.send(
+      new ListObjectsV2Command({
+        Bucket,
+        Prefix,
+        ContinuationToken: continuationToken,
+        MaxKeys: DELETE_BATCH,
+      })
+    );
+    const keys = (listed.Contents ?? [])
+      .map((object) => object.Key)
+      .filter((key): key is string => Boolean(key));
+    if (keys.length > 0) {
+      await s3.send(
+        new DeleteObjectsCommand({
+          Bucket,
+          Delete: { Objects: keys.map((Key) => ({ Key })), Quiet: true },
+        })
+      );
+    }
+    continuationToken = listed.IsTruncated
+      ? listed.NextContinuationToken
+      : undefined;
+  } while (continuationToken);
 }

--- a/apps/api/src/routes/conversations.ts
+++ b/apps/api/src/routes/conversations.ts
@@ -7,6 +7,7 @@ import {
 import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
 import { logger } from "../lib/logger.ts";
+import { deleteConversationMedia } from "../lib/media.ts";
 import { userId } from "../lib/user.ts";
 import { requireAuth } from "../middleware/auth.ts";
 import {
@@ -96,6 +97,13 @@ conversationsRoute.delete("/:id", async (c) => {
       logger.warn({ err: error, sandboxId }, "sandbox destroy failed")
     );
   }
+
+  // Drop the conversation's rendered videos from R2, out-of-band for the same
+  // reason — the delete shouldn't fail because object storage is unavailable.
+  const conversationId = c.req.param("id");
+  deleteConversationMedia(conversationId).catch((error) =>
+    logger.warn({ err: error, conversationId }, "media cleanup failed")
+  );
 
   return c.json({ ok: true });
 });

--- a/apps/api/src/routes/media.ts
+++ b/apps/api/src/routes/media.ts
@@ -1,35 +1,35 @@
-/** Serves rendered videos saved by the agent's renderScene tool. Intentionally
- * unauthenticated for v0.1 so the browser's <video> element (a cross-origin
- * subresource that won't carry the session cookie) can load it; the URLs carry
- * a random per-render id. Auth/signed URLs come with the R2 migration. */
+/** Mints short-lived presigned URLs for rendered videos stored in R2. The
+ * renderScene output carries only the object key; the web calls this route to
+ * resolve a key into a playable URL. Authenticated and ownership-checked: the
+ * key encodes its conversation id, and the caller must own that conversation. */
 
-import { readFile } from "node:fs/promises";
-import { basename, join } from "node:path";
 import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
-import { mediaRoot } from "../lib/media.ts";
+import { mediaKeyConversationId, signMediaUrl } from "../lib/media.ts";
+import { userId } from "../lib/user.ts";
+import { requireAuth } from "../middleware/auth.ts";
+import { userOwnsConversation } from "../services/conversations.ts";
+import type { AppEnv } from "../types.ts";
 
-const MP4_NAME = /^[\w-]+\.mp4$/;
+export const mediaRoute = new Hono<AppEnv>();
 
-export const mediaRoute = new Hono();
+mediaRoute.use("*", requireAuth);
 
-mediaRoute.get("/:conversationId/:file", async (c) => {
-  // basename strips any path-traversal; the regex pins the shape.
-  const conversationId = basename(c.req.param("conversationId"));
-  const file = basename(c.req.param("file"));
-  if (!MP4_NAME.test(file)) {
-    throw new HTTPException(400, { message: "Invalid media path" });
+mediaRoute.get("/sign", async (c) => {
+  const key = c.req.query("key");
+  const conversationId = key ? mediaKeyConversationId(key) : null;
+  if (!(key && conversationId)) {
+    throw new HTTPException(400, { message: "Invalid media key" });
   }
 
-  try {
-    const bytes = await readFile(join(mediaRoot(), conversationId, file));
-    return new Response(bytes, {
-      headers: {
-        "content-type": "video/mp4",
-        "cache-control": "private, max-age=3600",
-      },
-    });
-  } catch {
+  const owned = await userOwnsConversation({
+    conversationId,
+    userId: userId(c),
+  });
+  if (!owned) {
     throw new HTTPException(404, { message: "Media not found" });
   }
+
+  const url = await signMediaUrl(key);
+  return c.json({ url });
 });

--- a/apps/api/src/services/conversations.ts
+++ b/apps/api/src/services/conversations.ts
@@ -167,6 +167,24 @@ export async function listConversations({
   return { conversations: rows.map(serializeConversation), total };
 }
 
+/** Cheap ownership check — no message load — for gating per-object access. */
+export async function userOwnsConversation({
+  conversationId,
+  userId,
+}: {
+  conversationId: string;
+  userId: string;
+}): Promise<boolean> {
+  const row = await db.query.conversation.findFirst({
+    columns: { id: true },
+    where: and(
+      eq(conversation.id, conversationId),
+      eq(conversation.userId, userId)
+    ),
+  });
+  return Boolean(row);
+}
+
 export async function loadOwnedConversation({
   conversationId,
   userId,

--- a/apps/web/src/features/studio/components/chat-message.tsx
+++ b/apps/web/src/features/studio/components/chat-message.tsx
@@ -85,7 +85,7 @@ export function ChatMessage({
 	message: AnimusUIMessage;
 	isStreaming?: boolean;
 	respondToTool: RespondToTool;
-	onOpenVideo?: (url: string) => void;
+	onOpenVideo?: (key: string) => void;
 }) {
 	if (message.role === "user") {
 		return (

--- a/apps/web/src/features/studio/components/chat-panel.tsx
+++ b/apps/web/src/features/studio/components/chat-panel.tsx
@@ -22,7 +22,7 @@ export function ChatPanel({
 	respondToTool: RespondToTool;
 	onSubmit: (text: string) => void;
 	onStop: () => void;
-	onOpenVideo?: (url: string) => void;
+	onOpenVideo?: (key: string) => void;
 }) {
 	const lastIndex = messages.length - 1;
 	return (

--- a/apps/web/src/features/studio/components/studio-view.tsx
+++ b/apps/web/src/features/studio/components/studio-view.tsx
@@ -10,15 +10,15 @@ import type {
 } from "@/features/studio/types";
 
 /**
- * Notify the user when the explainer finishes (a video URL appears) while
+ * Notify the user when the explainer finishes (a rendered video appears) while
  * they're on another tab — the "leave and come back" promise from the panel.
  */
-function useRenderNotification(videoUrl: string | undefined) {
-	const previous = useRef(videoUrl);
+function useRenderNotification(videoKey: string | undefined) {
+	const previous = useRef(videoKey);
 
 	useEffect(() => {
-		const finished = !previous.current && Boolean(videoUrl);
-		previous.current = videoUrl;
+		const finished = !previous.current && Boolean(videoKey);
+		previous.current = videoKey;
 
 		if (
 			finished &&
@@ -33,14 +33,14 @@ function useRenderNotification(videoUrl: string | undefined) {
 			});
 			notification.onclick = () => window.focus();
 		}
-	}, [videoUrl]);
+	}, [videoKey]);
 }
 
 export function StudioStage({
 	phase,
 	messages,
 	status,
-	videoUrl,
+	videoKey,
 	title,
 	respondToTool,
 	onSubmit,
@@ -49,13 +49,13 @@ export function StudioStage({
 	phase: StudioPhase;
 	messages: AnimusUIMessage[];
 	status: ChatStatus;
-	videoUrl?: string;
+	videoKey?: string;
 	title: string;
 	respondToTool: RespondToTool;
 	onSubmit: (text: string) => void;
 	onStop: () => void;
 }) {
-	useRenderNotification(videoUrl);
+	useRenderNotification(videoKey);
 
 	return (
 		<>
@@ -71,7 +71,7 @@ export function StudioStage({
 					respondToTool={respondToTool}
 					status={status}
 					title={title}
-					videoUrl={videoUrl}
+					videoKey={videoKey}
 				/>
 			) : null}
 		</>

--- a/apps/web/src/features/studio/components/studio-workspace.tsx
+++ b/apps/web/src/features/studio/components/studio-workspace.tsx
@@ -15,7 +15,7 @@ import type { AnimusUIMessage, RespondToTool } from "@/features/studio/types";
 export function StudioWorkspace({
 	messages,
 	status,
-	videoUrl,
+	videoKey,
 	title,
 	respondToTool,
 	onSubmit,
@@ -23,7 +23,7 @@ export function StudioWorkspace({
 }: {
 	messages: AnimusUIMessage[];
 	status: ChatStatus;
-	videoUrl?: string;
+	videoKey?: string;
 	title: string;
 	respondToTool: RespondToTool;
 	onSubmit: (text: string) => void;
@@ -34,11 +34,11 @@ export function StudioWorkspace({
 	// A video pinned by clicking its chat card; falls back to the latest render.
 	// Clear the pin whenever a newer render lands so the panel follows the latest
 	// again — done during render (the previous-value pattern) to avoid an effect.
-	const [pinnedVideoUrl, setPinnedVideoUrl] = useState<string>();
-	const [lastVideoUrl, setLastVideoUrl] = useState(videoUrl);
-	if (videoUrl !== lastVideoUrl) {
-		setLastVideoUrl(videoUrl);
-		setPinnedVideoUrl(undefined);
+	const [pinnedVideoKey, setPinnedVideoKey] = useState<string>();
+	const [lastVideoKey, setLastVideoKey] = useState(videoKey);
+	if (videoKey !== lastVideoKey) {
+		setLastVideoKey(videoKey);
+		setPinnedVideoKey(undefined);
 	}
 	// Bumped on each chat-card click so the panel autoplays that video.
 	const [playToken, setPlayToken] = useState(0);
@@ -59,8 +59,8 @@ export function StudioWorkspace({
 		setIsVideoCollapsed(true);
 	};
 
-	const openVideo = useCallback((url: string) => {
-		setPinnedVideoUrl(url);
+	const openVideo = useCallback((key: string) => {
+		setPinnedVideoKey(key);
 		setPlayToken((token) => token + 1);
 		videoPanelRef.current?.expand();
 		setIsVideoCollapsed(false);
@@ -118,7 +118,7 @@ export function StudioWorkspace({
 					<VisualizationPanel
 						playToken={playToken}
 						title={title}
-						videoUrl={pinnedVideoUrl ?? videoUrl}
+						videoKey={pinnedVideoKey ?? videoKey}
 					/>
 				</div>
 			</ResizablePanel>

--- a/apps/web/src/features/studio/components/tools/manim-tools.tsx
+++ b/apps/web/src/features/studio/components/tools/manim-tools.tsx
@@ -18,6 +18,7 @@ import {
 	CollapsibleContent,
 	CollapsibleTrigger,
 } from "@/components/ui/collapsible";
+import { useSignedMediaUrl } from "@/features/studio/hooks/use-signed-media-url";
 import { cn } from "@/lib/utils";
 
 /** A compact one-line record of a sandbox action (write/read/list). */
@@ -133,6 +134,49 @@ export function EditFileTool({
 	);
 }
 
+/** The "your video is ready" artifact card. Resolves the R2 key to a presigned
+ * URL for the muted thumbnail frame; clicking opens it in the side panel. */
+function RenderedVideoCard({
+	scene,
+	videoKey,
+	onOpen,
+}: {
+	scene: string;
+	videoKey: string;
+	onOpen?: (key: string) => void;
+}) {
+	const { url } = useSignedMediaUrl(videoKey);
+	return (
+		<button
+			className="group my-3 flex w-full items-center gap-3 rounded-lg border bg-card p-2.5 text-left transition-colors hover:bg-accent"
+			onClick={() => onOpen?.(videoKey)}
+			type="button"
+		>
+			<span className="relative flex size-11 shrink-0 items-center justify-center overflow-hidden rounded-md border bg-black">
+				{/* A muted, controls-free frame as the artifact's thumbnail; playback
+				    happens in the side panel. biome-ignore lint/a11y/useMediaCaption: preview frame only. */}
+				<video
+					className="pointer-events-none h-full w-full object-cover"
+					muted
+					playsInline
+					preload="metadata"
+					src={url ?? undefined}
+				/>
+				<span className="absolute inset-0 flex items-center justify-center bg-black/30 transition-colors group-hover:bg-black/10">
+					<PlayIcon className="size-4 fill-white text-white" />
+				</span>
+			</span>
+			<span className="min-w-0 flex-1">
+				<span className="block font-medium text-sm">Your video is ready</span>
+				<span className="block truncate text-muted-foreground text-xs">
+					{scene}
+				</span>
+			</span>
+			<PlayIcon className="size-4 shrink-0 text-muted-foreground" />
+		</button>
+	);
+}
+
 export function RenderSceneTool({
 	input,
 	output,
@@ -140,38 +184,15 @@ export function RenderSceneTool({
 }: {
 	input: RenderSceneInput;
 	output: RenderSceneOutput;
-	onOpen?: (url: string) => void;
+	onOpen?: (key: string) => void;
 }) {
-	if (output.ok && output.videoUrl) {
-		const url = output.videoUrl;
+	if (output.ok && output.videoKey) {
 		return (
-			<button
-				className="group my-3 flex w-full items-center gap-3 rounded-lg border bg-card p-2.5 text-left transition-colors hover:bg-accent"
-				onClick={() => onOpen?.(url)}
-				type="button"
-			>
-				<span className="relative flex size-11 shrink-0 items-center justify-center overflow-hidden rounded-md border bg-black">
-					{/* A muted, controls-free frame as the artifact's thumbnail; playback
-					    happens in the side panel. biome-ignore lint/a11y/useMediaCaption: preview frame only. */}
-					<video
-						className="pointer-events-none h-full w-full object-cover"
-						muted
-						playsInline
-						preload="metadata"
-						src={url}
-					/>
-					<span className="absolute inset-0 flex items-center justify-center bg-black/30 transition-colors group-hover:bg-black/10">
-						<PlayIcon className="size-4 fill-white text-white" />
-					</span>
-				</span>
-				<span className="min-w-0 flex-1">
-					<span className="block font-medium text-sm">Your video is ready</span>
-					<span className="block truncate text-muted-foreground text-xs">
-						{input.scene}
-					</span>
-				</span>
-				<PlayIcon className="size-4 shrink-0 text-muted-foreground" />
-			</button>
+			<RenderedVideoCard
+				onOpen={onOpen}
+				scene={input.scene}
+				videoKey={output.videoKey}
+			/>
 		);
 	}
 

--- a/apps/web/src/features/studio/components/video-player.tsx
+++ b/apps/web/src/features/studio/components/video-player.tsx
@@ -23,6 +23,7 @@ import {
 	DropdownMenuItem,
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { useSignedMediaUrl } from "@/features/studio/hooks/use-signed-media-url";
 
 const PLAYBACK_SPEEDS = [0.5, 0.75, 1, 1.25, 1.5, 2] as const;
 const SEEK_STEP_SEC = 5;
@@ -44,14 +45,15 @@ function formatTime(seconds: number): string {
  * inactivity while playing and reappear on pointer/keyboard activity. Keyboard:
  * space/k play-pause, ←/→ seek, ↑/↓ volume, m mute, f fullscreen. */
 export function VideoPlayer({
-	url,
+	videoKey,
 	title,
 	playToken,
 }: {
-	url: string;
+	videoKey: string;
 	title: string;
 	playToken: number;
 }) {
+	const { url } = useSignedMediaUrl(videoKey);
 	const containerRef = useRef<HTMLDivElement>(null);
 	const videoRef = useRef<HTMLVideoElement>(null);
 	const hideTimerRef = useRef<number | null>(null);
@@ -303,7 +305,7 @@ export function VideoPlayer({
 				className="h-full w-full object-contain"
 				playsInline
 				ref={videoRef}
-				src={url}
+				src={url ?? undefined}
 			/>
 
 			{/* Title, top gradient. Right padding clears the panel's Hide button. */}

--- a/apps/web/src/features/studio/components/visualization-panel.tsx
+++ b/apps/web/src/features/studio/components/visualization-panel.tsx
@@ -48,18 +48,18 @@ function RenderingStage() {
 }
 
 export function VisualizationPanel({
-	videoUrl,
+	videoKey,
 	title,
 	playToken = 0,
 }: {
-	videoUrl?: string;
+	videoKey?: string;
 	title: string;
 	playToken?: number;
 }) {
 	return (
 		<div className="flex h-full flex-col bg-muted/30">
-			{videoUrl ? (
-				<VideoPlayer playToken={playToken} title={title} url={videoUrl} />
+			{videoKey ? (
+				<VideoPlayer playToken={playToken} title={title} videoKey={videoKey} />
 			) : (
 				<div className="flex flex-1 items-center justify-center overflow-auto p-6">
 					<RenderingStage />

--- a/apps/web/src/features/studio/hooks/use-signed-media-url.ts
+++ b/apps/web/src/features/studio/hooks/use-signed-media-url.ts
@@ -1,0 +1,79 @@
+/** Resolves an R2 media object key into a short-lived presigned playback URL by
+ * calling the API's /api/media/sign endpoint. Results are cached module-wide and
+ * refreshed before the presign expires, so the player and every chat card that
+ * reference the same key share one request. */
+
+import { useEffect, useState } from "react";
+import { apiFetch } from "@/lib/api";
+
+type CacheEntry = { url: string; fetchedAt: number };
+
+const cache = new Map<string, CacheEntry>();
+const inflight = new Map<string, Promise<string>>();
+/** Re-sign before the server's 1h presign lapses. */
+const REFRESH_MS = 50 * 60 * 1000;
+
+function fresh(entry: CacheEntry | undefined): string | undefined {
+	if (entry && Date.now() - entry.fetchedAt < REFRESH_MS) {
+		return entry.url;
+	}
+	return undefined;
+}
+
+function resolveKey(key: string): Promise<string> {
+	const cached = fresh(cache.get(key));
+	if (cached) {
+		return Promise.resolve(cached);
+	}
+	const existing = inflight.get(key);
+	if (existing) {
+		return existing;
+	}
+	const pending = apiFetch<{ url: string }>(
+		`/api/media/sign?key=${encodeURIComponent(key)}`,
+	)
+		.then((res) => {
+			cache.set(key, { url: res.url, fetchedAt: Date.now() });
+			return res.url;
+		})
+		.finally(() => inflight.delete(key));
+	inflight.set(key, pending);
+	return pending;
+}
+
+export function useSignedMediaUrl(key: string | undefined): {
+	url: string | undefined;
+	error: boolean;
+} {
+	const [url, setUrl] = useState<string | undefined>(() =>
+		key ? fresh(cache.get(key)) : undefined,
+	);
+	const [error, setError] = useState(false);
+
+	useEffect(() => {
+		if (!key) {
+			setUrl(undefined);
+			setError(false);
+			return;
+		}
+		let active = true;
+		setUrl(fresh(cache.get(key)));
+		setError(false);
+		resolveKey(key)
+			.then((resolved) => {
+				if (active) {
+					setUrl(resolved);
+				}
+			})
+			.catch(() => {
+				if (active) {
+					setError(true);
+				}
+			});
+		return () => {
+			active = false;
+		};
+	}, [key]);
+
+	return { url, error };
+}

--- a/apps/web/src/features/studio/hooks/use-studio-chat.ts
+++ b/apps/web/src/features/studio/hooks/use-studio-chat.ts
@@ -15,9 +15,10 @@ type StudioChat = {
 	messages: AnimusUIMessage[];
 	status: ChatStatus;
 	phase: StudioPhase;
-	/** Rendered explainer URL, once the render loop produces one. Undefined until
-	 * then — the side panel keeps animating while it's absent. */
-	videoUrl?: string;
+	/** R2 object key of the rendered explainer, once the render loop produces one.
+	 * Undefined until then — the side panel keeps animating while it's absent.
+	 * The player resolves it to a presigned URL via useSignedMediaUrl. */
+	videoKey?: string;
 	send: (text: string) => void;
 	stop: () => void;
 	respondToTool: RespondToTool;
@@ -102,19 +103,19 @@ export function useStudioChat({
 	}
 
 	// The latest successfully rendered scene drives the side panel's player.
-	let videoUrl: string | undefined;
+	let videoKey: string | undefined;
 	for (const message of messages) {
 		for (const part of message.parts) {
 			if (
 				part.type === "tool-renderScene" &&
 				part.state === "output-available" &&
 				part.output.ok &&
-				part.output.videoUrl
+				part.output.videoKey
 			) {
-				videoUrl = part.output.videoUrl;
+				videoKey = part.output.videoKey;
 			}
 		}
 	}
 
-	return { messages, status, phase, videoUrl, send, stop, respondToTool };
+	return { messages, status, phase, videoKey, send, stop, respondToTool };
 }

--- a/apps/web/src/pages/studio-page.tsx
+++ b/apps/web/src/pages/studio-page.tsx
@@ -61,7 +61,7 @@ function LoadedStudioChat({
 }) {
 	const location = useLocation();
 	const prompt = (location.state as { prompt?: string } | null)?.prompt;
-	const { messages, status, phase, videoUrl, respondToTool, send, stop } =
+	const { messages, status, phase, videoKey, respondToTool, send, stop } =
 		useStudioChat({
 			chatId,
 			initialPrompt: prompt,
@@ -80,7 +80,7 @@ function LoadedStudioChat({
 			respondToTool={respondToTool}
 			status={status}
 			title={detail.conversation.title}
-			videoUrl={videoUrl}
+			videoKey={videoKey}
 		/>
 	);
 }

--- a/bun.lock
+++ b/bun.lock
@@ -21,6 +21,8 @@
         "@animus/auth": "workspace:*",
         "@animus/core": "workspace:*",
         "@animus/db": "workspace:*",
+        "@aws-sdk/client-s3": "^3.1075.0",
+        "@aws-sdk/s3-request-presigner": "^3.1075.0",
         "ai": "^6.0.206",
         "hono": "^4.12.25",
         "pino": "^10.3.1",
@@ -194,7 +196,7 @@
 
     "@aws-sdk/checksums": ["@aws-sdk/checksums@3.1000.8", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@aws-crypto/crc32c": "5.2.0", "@aws-crypto/util": "5.2.0", "@aws-sdk/core": "^3.974.23", "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-v0U9S7gBIme3OTgt1LdbAF4RpvavCc+4GK1+1xqAcqtbrHsEhjQo6R45LKcjhs/+WrRJij1Y0Gztw7QPAIeUfA=="],
 
-    "@aws-sdk/client-s3": ["@aws-sdk/client-s3@3.1074.0", "", { "dependencies": { "@aws-crypto/sha1-browser": "5.2.0", "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.23", "@aws-sdk/credential-provider-node": "^3.972.58", "@aws-sdk/middleware-flexible-checksums": "^3.974.33", "@aws-sdk/middleware-sdk-s3": "^3.972.54", "@aws-sdk/signature-v4-multi-region": "^3.996.35", "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/fetch-http-handler": "^5.4.6", "@smithy/node-http-handler": "^4.7.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-NxC62ifhtaDDdJjZ8f8Y49DCOpviGGSwzdE4KO/DA1vui4dJP4CAq+64HQkdAjFw64i5cVZb5mF6off+pZX/pg=="],
+    "@aws-sdk/client-s3": ["@aws-sdk/client-s3@3.1075.0", "", { "dependencies": { "@aws-crypto/sha1-browser": "5.2.0", "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.23", "@aws-sdk/credential-provider-node": "^3.972.58", "@aws-sdk/middleware-flexible-checksums": "^3.974.33", "@aws-sdk/middleware-sdk-s3": "^3.972.54", "@aws-sdk/signature-v4-multi-region": "^3.996.35", "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/fetch-http-handler": "^5.4.6", "@smithy/node-http-handler": "^4.7.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-h1A6nIl1YX6Y45enGsTK7ef3ZrOnBiQJ1qF5R2K/nMWfsu6A9mc2Y5T66nxerABzyjjyyvign3MrzafnFoQKmA=="],
 
     "@aws-sdk/core": ["@aws-sdk/core@3.974.23", "", { "dependencies": { "@aws-sdk/types": "^3.973.13", "@aws-sdk/xml-builder": "^3.972.31", "@aws/lambda-invoke-store": "^0.2.2", "@smithy/core": "^3.24.6", "@smithy/signature-v4": "^5.4.6", "@smithy/types": "^4.14.3", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-MiWR/uWjxjFXGzrE0Ghc5lWxUxzHsUWFhV+OX7M4cR9SrmrnZs6TXavnCWnzzdwJeFri34xQo81rvGNzK3c4BQ=="],
 
@@ -221,6 +223,8 @@
     "@aws-sdk/middleware-sdk-s3": ["@aws-sdk/middleware-sdk-s3@3.972.54", "", { "dependencies": { "@aws-sdk/core": "^3.974.23", "@aws-sdk/signature-v4-multi-region": "^3.996.35", "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-GDfDQ0gwLFRKN9gWIKcmVrHJ3e7XagnY7N1LLzMVNgnOnuY7f/ALgmy3CuBjosWD95T/Z6e+gs1IeWmLPkyLKQ=="],
 
     "@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.997.23", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.23", "@aws-sdk/signature-v4-multi-region": "^3.996.35", "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/fetch-http-handler": "^5.4.6", "@smithy/node-http-handler": "^4.7.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-gO93ZPsI2bxeFZD42f1/qjDw6FAZkNZcKRO94LIiT03fzOmcJ9e/tunxjVjA1Rl69ClmVJzz8H3G9CdKef10PA=="],
+
+    "@aws-sdk/s3-request-presigner": ["@aws-sdk/s3-request-presigner@3.1075.0", "", { "dependencies": { "@aws-sdk/core": "^3.974.23", "@aws-sdk/signature-v4-multi-region": "^3.996.35", "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-++ftTvAGZSTuzFVHEPk8lLi7mybBD8PzJ9USWBvwnE4kSrXOyqYVJ5Ixd06xUEWS/xsrhpkI07mzCLGIxrRymA=="],
 
     "@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.996.35", "", { "dependencies": { "@aws-sdk/types": "^3.973.13", "@smithy/signature-v4": "^5.4.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-6L/VWs+Wch2stHemCGTmUNqKLMzURxQDK5boNG3Jn3kAOp71meDUuS5sbObpEvFxHDq0uWeSLFDNSYsjNt+Dlg=="],
 
@@ -1046,7 +1050,7 @@
 
     "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@4.0.0", "", {}, "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="],
 
-    "@smithy/core": ["@smithy/core@3.25.1", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-zpDbpXBCBsxfLtG2GEUyfgvHvSFrw5CwDZSNzL0v52gx/c3oPlPbm+7W7num8xs6vyiUBn+bvYPHcQDOXZynCQ=="],
+    "@smithy/core": ["@smithy/core@3.26.0", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-mLUktFAn+Pa2agl1J7VgtYNFWCX8/b4GMJSK1hCu4YCvtBfM6F8Os3EP4ry+DFFlXOf3wyvlgXhuUdFoy52D3g=="],
 
     "@smithy/credential-provider-imds": ["@smithy/credential-provider-imds@4.4.2", "", { "dependencies": { "@smithy/core": "^3.26.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-18UMDMyrAbDcpmL1gLUA7ww0fRTcdCrSjSJOi2Sbld+tVjwD/pW+OAwjlScFLR7vvBnhZrIPQ7kVuTf1mnJLug=="],
 
@@ -2978,35 +2982,7 @@
 
     "@aws-crypto/util/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
 
-    "@aws-sdk/checksums/@smithy/core": ["@smithy/core@3.26.0", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-mLUktFAn+Pa2agl1J7VgtYNFWCX8/b4GMJSK1hCu4YCvtBfM6F8Os3EP4ry+DFFlXOf3wyvlgXhuUdFoy52D3g=="],
-
-    "@aws-sdk/core/@smithy/core": ["@smithy/core@3.26.0", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-mLUktFAn+Pa2agl1J7VgtYNFWCX8/b4GMJSK1hCu4YCvtBfM6F8Os3EP4ry+DFFlXOf3wyvlgXhuUdFoy52D3g=="],
-
-    "@aws-sdk/credential-provider-env/@smithy/core": ["@smithy/core@3.26.0", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-mLUktFAn+Pa2agl1J7VgtYNFWCX8/b4GMJSK1hCu4YCvtBfM6F8Os3EP4ry+DFFlXOf3wyvlgXhuUdFoy52D3g=="],
-
-    "@aws-sdk/credential-provider-http/@smithy/core": ["@smithy/core@3.26.0", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-mLUktFAn+Pa2agl1J7VgtYNFWCX8/b4GMJSK1hCu4YCvtBfM6F8Os3EP4ry+DFFlXOf3wyvlgXhuUdFoy52D3g=="],
-
-    "@aws-sdk/credential-provider-ini/@smithy/core": ["@smithy/core@3.26.0", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-mLUktFAn+Pa2agl1J7VgtYNFWCX8/b4GMJSK1hCu4YCvtBfM6F8Os3EP4ry+DFFlXOf3wyvlgXhuUdFoy52D3g=="],
-
-    "@aws-sdk/credential-provider-login/@smithy/core": ["@smithy/core@3.26.0", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-mLUktFAn+Pa2agl1J7VgtYNFWCX8/b4GMJSK1hCu4YCvtBfM6F8Os3EP4ry+DFFlXOf3wyvlgXhuUdFoy52D3g=="],
-
-    "@aws-sdk/credential-provider-node/@smithy/core": ["@smithy/core@3.26.0", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-mLUktFAn+Pa2agl1J7VgtYNFWCX8/b4GMJSK1hCu4YCvtBfM6F8Os3EP4ry+DFFlXOf3wyvlgXhuUdFoy52D3g=="],
-
-    "@aws-sdk/credential-provider-process/@smithy/core": ["@smithy/core@3.26.0", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-mLUktFAn+Pa2agl1J7VgtYNFWCX8/b4GMJSK1hCu4YCvtBfM6F8Os3EP4ry+DFFlXOf3wyvlgXhuUdFoy52D3g=="],
-
-    "@aws-sdk/credential-provider-sso/@smithy/core": ["@smithy/core@3.26.0", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-mLUktFAn+Pa2agl1J7VgtYNFWCX8/b4GMJSK1hCu4YCvtBfM6F8Os3EP4ry+DFFlXOf3wyvlgXhuUdFoy52D3g=="],
-
-    "@aws-sdk/credential-provider-web-identity/@smithy/core": ["@smithy/core@3.26.0", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-mLUktFAn+Pa2agl1J7VgtYNFWCX8/b4GMJSK1hCu4YCvtBfM6F8Os3EP4ry+DFFlXOf3wyvlgXhuUdFoy52D3g=="],
-
-    "@aws-sdk/lib-storage/@smithy/core": ["@smithy/core@3.26.0", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-mLUktFAn+Pa2agl1J7VgtYNFWCX8/b4GMJSK1hCu4YCvtBfM6F8Os3EP4ry+DFFlXOf3wyvlgXhuUdFoy52D3g=="],
-
     "@aws-sdk/lib-storage/buffer": ["buffer@5.6.0", "", { "dependencies": { "base64-js": "^1.0.2", "ieee754": "^1.1.4" } }, "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw=="],
-
-    "@aws-sdk/middleware-sdk-s3/@smithy/core": ["@smithy/core@3.26.0", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-mLUktFAn+Pa2agl1J7VgtYNFWCX8/b4GMJSK1hCu4YCvtBfM6F8Os3EP4ry+DFFlXOf3wyvlgXhuUdFoy52D3g=="],
-
-    "@aws-sdk/nested-clients/@smithy/core": ["@smithy/core@3.26.0", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-mLUktFAn+Pa2agl1J7VgtYNFWCX8/b4GMJSK1hCu4YCvtBfM6F8Os3EP4ry+DFFlXOf3wyvlgXhuUdFoy52D3g=="],
-
-    "@aws-sdk/token-providers/@smithy/core": ["@smithy/core@3.26.0", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-mLUktFAn+Pa2agl1J7VgtYNFWCX8/b4GMJSK1hCu4YCvtBfM6F8Os3EP4ry+DFFlXOf3wyvlgXhuUdFoy52D3g=="],
 
     "@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
@@ -3059,6 +3035,8 @@
     "@better-auth/sso/@better-auth/utils": ["@better-auth/utils@0.4.2", "", { "dependencies": { "@noble/hashes": "^2.0.1" } }, "sha512-AUxrvu+HaaODsUyzDxFgwd/8RZ1yZaYo42LXKSrU2oGgR38pS1ij8nqQKNgtTWoYGpNevNXtCfgTy6loHveW9A=="],
 
     "@better-auth/telemetry/@better-fetch/fetch": ["@better-fetch/fetch@1.1.21", "", {}, "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A=="],
+
+    "@daytonaio/sdk/@aws-sdk/client-s3": ["@aws-sdk/client-s3@3.1074.0", "", { "dependencies": { "@aws-crypto/sha1-browser": "5.2.0", "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.23", "@aws-sdk/credential-provider-node": "^3.972.58", "@aws-sdk/middleware-flexible-checksums": "^3.974.33", "@aws-sdk/middleware-sdk-s3": "^3.972.54", "@aws-sdk/signature-v4-multi-region": "^3.996.35", "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/fetch-http-handler": "^5.4.6", "@smithy/node-http-handler": "^4.7.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-NxC62ifhtaDDdJjZ8f8Y49DCOpviGGSwzdE4KO/DA1vui4dJP4CAq+64HQkdAjFw64i5cVZb5mF6off+pZX/pg=="],
 
     "@dotenvx/dotenvx/commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
 
@@ -3228,13 +3206,9 @@
 
     "@rc-component/trigger/@rc-component/portal": ["@rc-component/portal@2.2.1", "", { "dependencies": { "@rc-component/util": "^1.11.0", "clsx": "^2.1.1" }, "peerDependencies": { "react": ">=18.0.0", "react-dom": ">=18.0.0" } }, "sha512-ck+r1kW/JSv0wxPji3KN2ss9K6Z0qqwusw/mf/0JobXhZ8hC2ejZwCJObW/SvDi0uhA0VzmCnx0CaCci95tcmA=="],
 
-    "@smithy/credential-provider-imds/@smithy/core": ["@smithy/core@3.26.0", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-mLUktFAn+Pa2agl1J7VgtYNFWCX8/b4GMJSK1hCu4YCvtBfM6F8Os3EP4ry+DFFlXOf3wyvlgXhuUdFoy52D3g=="],
+    "@smithy/eventstream-codec/@smithy/core": ["@smithy/core@3.25.1", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-zpDbpXBCBsxfLtG2GEUyfgvHvSFrw5CwDZSNzL0v52gx/c3oPlPbm+7W7num8xs6vyiUBn+bvYPHcQDOXZynCQ=="],
 
-    "@smithy/fetch-http-handler/@smithy/core": ["@smithy/core@3.26.0", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-mLUktFAn+Pa2agl1J7VgtYNFWCX8/b4GMJSK1hCu4YCvtBfM6F8Os3EP4ry+DFFlXOf3wyvlgXhuUdFoy52D3g=="],
-
-    "@smithy/node-http-handler/@smithy/core": ["@smithy/core@3.26.0", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-mLUktFAn+Pa2agl1J7VgtYNFWCX8/b4GMJSK1hCu4YCvtBfM6F8Os3EP4ry+DFFlXOf3wyvlgXhuUdFoy52D3g=="],
-
-    "@smithy/signature-v4/@smithy/core": ["@smithy/core@3.26.0", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-mLUktFAn+Pa2agl1J7VgtYNFWCX8/b4GMJSK1hCu4YCvtBfM6F8Os3EP4ry+DFFlXOf3wyvlgXhuUdFoy52D3g=="],
+    "@smithy/util-utf8/@smithy/core": ["@smithy/core@3.25.1", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-zpDbpXBCBsxfLtG2GEUyfgvHvSFrw5CwDZSNzL0v52gx/c3oPlPbm+7W7num8xs6vyiUBn+bvYPHcQDOXZynCQ=="],
 
     "@streamdown/code/shiki": ["shiki@3.23.0", "", { "dependencies": { "@shikijs/core": "3.23.0", "@shikijs/engine-javascript": "3.23.0", "@shikijs/engine-oniguruma": "3.23.0", "@shikijs/langs": "3.23.0", "@shikijs/themes": "3.23.0", "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA=="],
 
@@ -3411,6 +3385,8 @@
     "@better-auth/cli/better-auth/kysely": ["kysely@0.28.17", "", {}, "sha512-nbD8lB9EB3wNdMhOCdx5Li8DxnLbvKByylRLcJ1h+4SkrowVeECAyZlyiKMThF7xFdRz0jSQ2MoJr+wXux2y0Q=="],
 
     "@better-auth/core/better-call/@better-fetch/fetch": ["@better-fetch/fetch@1.3.1", "", {}, "sha512-ABkD1WhyfPZprKRQI3bhATjeiFuNWC9PXhfGWqL+sg/gKrM977oFrYkdb4msM3hgUGonr7KlOsOFT5TU2rht9g=="],
+
+    "@daytonaio/sdk/@aws-sdk/client-s3/@smithy/core": ["@smithy/core@3.25.1", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-zpDbpXBCBsxfLtG2GEUyfgvHvSFrw5CwDZSNzL0v52gx/c3oPlPbm+7W7num8xs6vyiUBn+bvYPHcQDOXZynCQ=="],
 
     "@dotenvx/dotenvx/execa/get-stream": ["get-stream@6.0.1", "", {}, "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="],
 

--- a/packages/agent/src/tools/manim.ts
+++ b/packages/agent/src/tools/manim.ts
@@ -26,8 +26,8 @@ const FILE_READY = /File ready at\s+'?([^'\n]+\.mp4)'?/;
 const DIR_PREFIX = /^.*\//;
 const PY_SUFFIX = /\.py$/;
 
-/** Persist a rendered video and return an absolute URL the web can embed.
- * Implemented by the API (local disk in v0.1, object storage later). */
+/** Persist a rendered video and return its storage key (an R2 object key the
+ * web resolves to a presigned URL). Implemented by the API. */
 export type SaveVideo = (input: {
   bytes: Uint8Array;
   conversationId: string;
@@ -194,12 +194,12 @@ export function createManimTools(deps: {
         const path = outputPath(output, file, scene, quality);
         try {
           const buffer = await sandbox.fs.downloadFile(path);
-          const videoUrl = await saveVideo({
+          const videoKey = await saveVideo({
             bytes: new Uint8Array(buffer),
             conversationId,
             scene,
           });
-          return { ok: true, file, scene, exitCode: 0, videoUrl, logs };
+          return { ok: true, file, scene, exitCode: 0, videoKey, logs };
         } catch (error) {
           return {
             ok: false,

--- a/packages/core/src/__tests__/env.test.ts
+++ b/packages/core/src/__tests__/env.test.ts
@@ -4,6 +4,10 @@ import { parseServerEnv } from "../env/server.ts";
 const MINIMAL = {
   DATABASE_URL: "postgres://u:p@localhost:5432/db",
   BETTER_AUTH_SECRET: "a-test-secret",
+  R2_ACCOUNT_ID: "acct",
+  R2_ACCESS_KEY_ID: "akid",
+  R2_SECRET_ACCESS_KEY: "secret",
+  R2_BUCKET: "animus-videos",
 };
 
 describe("parseServerEnv", () => {
@@ -47,5 +51,18 @@ describe("parseServerEnv", () => {
 
   it("rejects an invalid NODE_ENV", () => {
     expect(() => parseServerEnv({ ...MINIMAL, NODE_ENV: "staging" })).toThrow();
+  });
+
+  it("maps the R2 storage credentials", () => {
+    const env = parseServerEnv(MINIMAL);
+    expect(env.r2AccountId).toBe("acct");
+    expect(env.r2AccessKeyId).toBe("akid");
+    expect(env.r2SecretAccessKey).toBe("secret");
+    expect(env.r2Bucket).toBe("animus-videos");
+  });
+
+  it("throws when an R2 variable is missing", () => {
+    const { R2_BUCKET, ...withoutBucket } = MINIMAL;
+    expect(() => parseServerEnv(withoutBucket)).toThrow("R2_BUCKET");
   });
 });

--- a/packages/core/src/env/server.ts
+++ b/packages/core/src/env/server.ts
@@ -48,14 +48,16 @@ const ServerEnvSchema = z.object({
   DAYTONA_API_KEY: z.string().optional(),
   /** Optional Daytona region/target (e.g. "us", "eu"). */
   DAYTONA_TARGET: z.string().optional(),
-  /** Public base URL of this API, used to build absolute URLs for served media. (TEMP)
-   * TODO: TO BE REPLACED WITH PROPER STORAGE SOLUTION LATER ON ...
-   */
-  API_PUBLIC_URL: z.url().default("http://localhost:8787"),
+  /** Cloudflare R2 (S3-compatible) storage for rendered videos. The endpoint is
+   * derived from the account id; the browser streams videos from R2 via
+   * short-lived presigned URLs minted by the media route. */
+  R2_ACCOUNT_ID: z.string().min(1, "R2_ACCOUNT_ID is required"),
+  R2_ACCESS_KEY_ID: z.string().min(1, "R2_ACCESS_KEY_ID is required"),
+  R2_SECRET_ACCESS_KEY: z.string().min(1, "R2_SECRET_ACCESS_KEY is required"),
+  R2_BUCKET: z.string().min(1, "R2_BUCKET is required"),
 });
 
 export interface ServerEnv {
-  apiPublicUrl: string;
   bedrockModel: string;
   betterAuthApiKey?: string;
   betterAuthSecret: string;
@@ -72,6 +74,10 @@ export interface ServerEnv {
   logLevel?: "fatal" | "error" | "warn" | "info" | "debug" | "trace";
   nodeEnv: "development" | "test" | "production";
   port: number;
+  r2AccessKeyId: string;
+  r2AccountId: string;
+  r2Bucket: string;
+  r2SecretAccessKey: string;
   resendApiKey?: string;
   resendFrom: string;
   webOrigin: string;
@@ -103,7 +109,10 @@ export function parseServerEnv(
     exaApiKey: e.EXA_API_KEY,
     daytonaApiKey: e.DAYTONA_API_KEY,
     daytonaTarget: e.DAYTONA_TARGET,
-    apiPublicUrl: e.API_PUBLIC_URL,
+    r2AccountId: e.R2_ACCOUNT_ID,
+    r2AccessKeyId: e.R2_ACCESS_KEY_ID,
+    r2SecretAccessKey: e.R2_SECRET_ACCESS_KEY,
+    r2Bucket: e.R2_BUCKET,
     logLevel: e.LOG_LEVEL,
     betterAuthSecret: e.BETTER_AUTH_SECRET,
     betterAuthUrl: e.BETTER_AUTH_URL,

--- a/packages/core/src/tools/manim.ts
+++ b/packages/core/src/tools/manim.ts
@@ -94,6 +94,7 @@ export interface RenderSceneOutput {
   logs: string;
   ok: boolean;
   scene: string;
-  /** Absolute URL to the rendered mp4 when ok; absent on failure. */
-  videoUrl?: string;
+  /** R2 object key of the rendered mp4 when ok; absent on failure. The web
+   * resolves it to a short-lived presigned URL via the media route. */
+  videoKey?: string;
 }


### PR DESCRIPTION
## What this does

Moves rendered videos off the API's local disk onto **Cloudflare R2**, served to the browser via short-lived **presigned URLs**. Replaces the temporary unauthenticated `/api/media` byte-serving route.

### How it works
1. `renderScene` renders in the sandbox, downloads the mp4, and `saveVideo` uploads it to R2 — returning the **object key** (`videos/<conversationId>/<scene>-<rand>.mp4`), not a URL.
2. The key is what's persisted in the message snapshot, so a saved conversation stays replayable (no expiring URL baked in).
3. The web exchanges a key for a 1h presigned URL via authenticated `GET /api/media/sign?key=…` (ownership-checked), then streams **directly from R2** (range/seeking handled by R2; the API never proxies bytes).
4. Deleting a conversation also deletes its R2 objects, out-of-band like the sandbox teardown.

### Key decisions (confirmed)
- **Presigned URLs** (store key, sign on load) over an API proxy or capability URLs.
- **R2 required** — the API fails fast at startup without `R2_*`; no local-disk fallback.
- **Delete on conversation delete**, unique key per render.

## Changes
- **core**: required `R2_ACCOUNT_ID/ACCESS_KEY_ID/SECRET_ACCESS_KEY/BUCKET`; dropped the now-unused `API_PUBLIC_URL`. `RenderSceneOutput.videoUrl` → `videoKey`.
- **api**: R2 lib (`saveVideo`/`signMediaUrl`/`deleteConversationMedia`/key validation); authenticated `/api/media/sign` route; `userOwnsConversation` cheap ownership check; delete-on-delete cleanup. Adds `@aws-sdk/client-s3` + `s3-request-presigner`.
- **agent**: `renderScene` returns `videoKey`.
- **web**: `useSignedMediaUrl(key)` hook (cached, re-signed before expiry, deduped); `videoKey` threaded through the studio; player + render card resolve on demand.

## Deploy notes
- Set `R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_BUCKET` in `.env` (endpoint is derived from the account id). **API won't boot without them.**

## Tests
R2 lib (upload/sign/delete/pagination/key-validation), sign route (400/404/200 + ownership), env required. Full gate green: typecheck, ultracite, knip, **86 tests**.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Store rendered videos in Cloudflare R2 and stream them via short‑lived presigned URLs, replacing local disk and the unauthenticated media route. Playback is secure and direct from R2; the API no longer proxies bytes.

- **New Features**
  - Upload renders to R2 and persist only the object key (`videos/<conversationId>/<scene>-<rand>.mp4`).
  - New authenticated `GET /api/media/sign?key=…` that ownership-checks and returns a 1h presigned URL.
  - Web resolves keys with `useSignedMediaUrl` (cached, re-signs before expiry) and streams directly from R2.
  - Agent and UI now use `videoKey` instead of `videoUrl`.
  - Deleting a conversation also deletes its R2 objects in the background.

- **Migration**
  - Set `R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_BUCKET` in the API env. The API fails fast without them.
  - `API_PUBLIC_URL` is no longer used.

<sup>Written for commit 120830a2a87e035fcfb092764074e79af16dd83f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/KacemMathlouthi/animus/pull/11?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

