### PR TITLE
fix(web): stop re-sending the initial prompt on refresh

### DIFF
--- a/apps/web/src/features/studio/hooks/use-studio-chat.ts
+++ b/apps/web/src/features/studio/hooks/use-studio-chat.ts
@@ -55,11 +55,15 @@ export function useStudioChat({
 			},
 		});
 
-	// Auto-run the first prompt exactly once for a new conversation.
+	// Auto-run the first prompt exactly once for a genuinely new conversation.
+	// Capture whether the loaded snapshot already had messages at mount: router
+	// navigation state keeps the prompt across a hard refresh, so without this
+	// guard a refresh would re-send it and duplicate the turn.
 	const autoSent = useRef(false);
+	const hadInitialMessages = useRef((initialMessages?.length ?? 0) > 0).current;
 	const [initialSendFailed, setInitialSendFailed] = useState(false);
 	useEffect(() => {
-		if (initialPrompt && !autoSent.current) {
+		if (initialPrompt && !(autoSent.current || hadInitialMessages)) {
 			autoSent.current = true;
 			setInitialSendFailed(false);
 			void sendMessage({ text: initialPrompt }).catch(() => {
@@ -67,7 +71,7 @@ export function useStudioChat({
 				setInitialSendFailed(true);
 			});
 		}
-	}, [initialPrompt, sendMessage]);
+	}, [initialPrompt, hadInitialMessages, sendMessage]);
 
 	const send = useCallback(
 		(text: string) => {


### PR DESCRIPTION
## Bug
Refreshing a studio conversation re-sent the original prompt, duplicating the turn (e.g. the plan/intro generated twice).

## Cause
The initial prompt is carried in React Router navigation state, which the browser persists in `history.state` across a hard refresh. The `autoSent` ref that should make the prompt fire "exactly once" is reset to `false` on remount, and there was no guard against the conversation *already having messages* — so the effect re-sent it.

## Fix
Capture whether the loaded snapshot already had messages at mount and only auto-send when it didn't:

```ts
if (initialPrompt && !(autoSent.current || hadInitialMessages)) { ... }
```

A genuinely fresh conversation still auto-runs its prompt; a refresh of an existing one does not.

## Notes
- No unit test: this is a one-line guard in a React hook and `apps/web` has no test runner set up (UI is verified manually). Happy to add web test infra separately if you want coverage here.
- Stops the client from re-sending. If a conversation was already doubled before this fix, those rows are already persisted — say the word if you want me to check whether the chat sync contract should dedup a repeated first message.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop re-sending the initial prompt on refresh in Studio chat. We now auto-send the prompt only if the loaded conversation has no messages, preventing duplicate first turns.

<sup>Written for commit bd859702e0ea0da7b92b5e068d23883112deee2b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/KacemMathlouthi/animus/pull/12?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

