### PR TITLE
feat: background music muxed into rendered videos

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,8 +84,11 @@ titles; sidebar list/search/rename/delete) → streaming chat ✓ (`/api/chat` �
 first Manim scene end-to-end via Daytona ✓ → R2 video storage ✓ (rendered mp4s
 live in R2; the agent's renderScene returns an object key, the web streams via
 short-lived presigned URLs minted by `/api/media/sign`, and a conversation's
-objects are deleted with it) → **next:** generalize the render/repair loop +
-narration + playback polish → later: quota/billing, autonomous mode. (Outstanding before the chat phase fully closes: HTTP-level
+objects are deleted with it) → background music ✓ (renderScene fetches a track
+from R2 at render time and muxes it under the video via ffmpeg, with a silent
+fallback; fixed `music/background.mp3` key for now, user-configurable later) →
+**next:** narration (TTS) → playback polish → generalize the render/repair loop
+→ later: quota/billing, autonomous mode. (Outstanding before the chat phase fully closes: HTTP-level
 route tests for `conversations` + the `/api/chat` sync contract, and an atomic
 title-generation claim.)
 

--- a/apps/api/src/__tests__/media.lib.test.ts
+++ b/apps/api/src/__tests__/media.lib.test.ts
@@ -35,6 +35,7 @@ vi.mock("@aws-sdk/client-s3", () => {
 vi.mock("@aws-sdk/s3-request-presigner", () => ({ getSignedUrl }));
 
 const {
+  backgroundMusicUrl,
   deleteConversationMedia,
   mediaKeyConversationId,
   saveVideo,
@@ -91,6 +92,21 @@ describe("mediaKeyConversationId", () => {
     expect(mediaKeyConversationId("videos/conv1/scene.txt")).toBeNull();
     expect(mediaKeyConversationId("../../etc/passwd")).toBeNull();
     expect(mediaKeyConversationId("videos/conv1/../x.mp4")).toBeNull();
+  });
+});
+
+describe("backgroundMusicUrl", () => {
+  it("presigns a GET for the fixed background music key", async () => {
+    getSignedUrl.mockResolvedValue("https://signed/music");
+
+    const url = await backgroundMusicUrl();
+
+    expect(url).toBe("https://signed/music");
+    const command = getSignedUrl.mock.calls[0]?.[1];
+    expect(command.input).toMatchObject({
+      Bucket: "animus-videos",
+      Key: "music/The_Merchants_Of_Death.mp3",
+    });
   });
 });
 

--- a/apps/api/src/lib/media.ts
+++ b/apps/api/src/lib/media.ts
@@ -23,6 +23,9 @@ const UNSAFE_NAME_CHARS = /[^a-zA-Z0-9_-]/g;
 const MEDIA_PREFIX = "videos";
 /** videos/<conversationId>/<file>.mp4 — pins the shape we mint and accept. */
 const MEDIA_KEY = /^videos\/([a-zA-Z0-9_-]+)\/[a-zA-Z0-9_-]+\.mp4$/;
+/** Fixed object key for the background track muxed under every render. Hardcoded
+ * for now; a user-configurable key is a later iteration. */
+const MUSIC_KEY = "music/The_Merchants_Of_Death.mp3";
 
 let client: S3Client | null = null;
 
@@ -76,6 +79,13 @@ export async function saveVideo(input: {
     })
   );
   return key;
+}
+
+/** Presigned GET URL for the background track, so the sandbox can download it
+ * straight from R2 (no byte round-trip through the API). If the object is
+ * absent the download simply fails and renderScene delivers a silent video. */
+export function backgroundMusicUrl(): Promise<string> {
+  return signMediaUrl(MUSIC_KEY);
 }
 
 /** Mint a short-lived presigned GET URL the browser can stream from directly. */

--- a/apps/api/src/routes/chat.ts
+++ b/apps/api/src/routes/chat.ts
@@ -8,7 +8,7 @@ import { createManimAgent, ensureSandbox } from "@animus/agent";
 import { convertToModelMessages, createIdGenerator } from "ai";
 import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
-import { saveVideo } from "../lib/media.ts";
+import { backgroundMusicUrl, saveVideo } from "../lib/media.ts";
 import { userId } from "../lib/user.ts";
 import { requireAuth } from "../middleware/auth.ts";
 import { maybeGenerateConversationTitle } from "../services/conversation-titles.ts";
@@ -57,7 +57,12 @@ chatRoute.post("/", async (c) => {
     await setConversationSandboxId(conversationId, sandbox.id);
   }
 
-  const agent = createManimAgent({ sandbox, conversationId, saveVideo });
+  const agent = createManimAgent({
+    sandbox,
+    conversationId,
+    saveVideo,
+    backgroundMusicUrl,
+  });
   const result = await agent.stream({
     abortSignal: c.req.raw.signal,
     prompt: await convertToModelMessages(messages),

--- a/packages/agent/src/__tests__/manim-tools.test.ts
+++ b/packages/agent/src/__tests__/manim-tools.test.ts
@@ -59,6 +59,7 @@ function editTool(initial: Record<string, string>) {
     sandbox: state.sandbox,
     conversationId: "conv-1",
     saveVideo: vi.fn(() => Promise.resolve("https://example.com/v.mp4")),
+    backgroundMusicUrl: vi.fn(() => Promise.resolve("https://music.test")),
   });
   const edit = tools.editFile;
   if (!edit?.execute) {
@@ -73,6 +74,7 @@ function runTool(commandOut: string) {
     sandbox: state.sandbox,
     conversationId: "conv-1",
     saveVideo: vi.fn(() => Promise.resolve("https://example.com/v.mp4")),
+    backgroundMusicUrl: vi.fn(() => Promise.resolve("https://music.test")),
   });
   const run = tools.runCommand;
   if (!run?.execute) {
@@ -199,5 +201,107 @@ describe("runCommand log truncation", () => {
     expect(output.output).toContain("truncated 500 earlier characters");
     // The marker plus exactly the last MAX_LOG_CHARS of the original output.
     expect(output.output.endsWith("x".repeat(MAX_LOG_CHARS))).toBe(true);
+  });
+});
+
+const MASTER = "/home/daytona/project/media/videos/scene/1080p60/Main.mp4";
+const MUSIC_MASTER =
+  "/home/daytona/project/media/videos/scene/1080p60/Main.music.mp4";
+const STAGED_TRACK = "/home/daytona/project/.background-music.mp3";
+const MUSIC_URL = "https://r2.example/music?sig=abc";
+const MUSIC_SKIPPED = /background music skipped/;
+
+function renderSandbox(opts: { renderExit?: number; muxExit?: number }) {
+  const downloadCalls: string[] = [];
+  const saveVideo = vi.fn(() =>
+    Promise.resolve("videos/conv/Main-ab12cd34.mp4")
+  );
+  const backgroundMusicUrl = vi.fn(() => Promise.resolve(MUSIC_URL));
+  const executeCommand = vi.fn(
+    (command: string, _cwd?: string, _env?: Record<string, string>) => {
+      if (command.includes("manim render")) {
+        return Promise.resolve({
+          exitCode: opts.renderExit ?? 0,
+          result: `Rendering scene\nFile ready at '${MASTER}'\n`,
+        });
+      }
+      // download + ffmpeg mux
+      return Promise.resolve({ exitCode: opts.muxExit ?? 0, result: "" });
+    }
+  );
+  const sandbox = {
+    process: { executeCommand },
+    fs: {
+      downloadFile: vi.fn((path: string) => {
+        downloadCalls.push(path);
+        return Promise.resolve(Buffer.from("video-bytes"));
+      }),
+    },
+  } as unknown as Sandbox;
+  const tools = createManimTools({
+    sandbox,
+    conversationId: "conv",
+    saveVideo,
+    backgroundMusicUrl,
+  });
+  const render = tools.renderScene;
+  if (!render?.execute) {
+    throw new Error("renderScene tool is not executable");
+  }
+  return { execute: render.execute, downloadCalls, saveVideo, executeCommand };
+}
+
+const RENDER_INPUT = {
+  file: "scene.py",
+  scene: "Main",
+  quality: "high",
+} as const;
+
+describe("renderScene background music", () => {
+  it("downloads the track in-sandbox, muxes it, and delivers the muxed file", async () => {
+    const { execute, downloadCalls, saveVideo, executeCommand } = renderSandbox(
+      {}
+    );
+
+    const output = await execute(RENDER_INPUT, EXEC_CTX);
+
+    expect(output.ok).toBe(true);
+    expect(output.videoKey).toBe("videos/conv/Main-ab12cd34.mp4");
+    // Second sandbox command downloads the track then muxes it; the presigned
+    // URL rides in the env, not the command string.
+    const [muxCommand, , muxEnv] = executeCommand.mock.calls[1] ?? [];
+    expect(muxCommand).toContain("urlretrieve");
+    expect(muxCommand).toContain("ffmpeg");
+    expect(muxCommand).toContain(STAGED_TRACK);
+    expect(muxCommand).toContain(MUSIC_MASTER);
+    expect(muxEnv).toEqual({ MUSIC_URL });
+    // The muxed file (not the silent master) is what gets uploaded.
+    expect(downloadCalls).toEqual([MUSIC_MASTER]);
+    expect(saveVideo).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to the silent master when the music step fails", async () => {
+    const { execute, downloadCalls, saveVideo } = renderSandbox({ muxExit: 1 });
+
+    const output = await execute(RENDER_INPUT, EXEC_CTX);
+
+    expect(output.ok).toBe(true);
+    expect(output.videoKey).toBe("videos/conv/Main-ab12cd34.mp4");
+    expect(output.logs).toMatch(MUSIC_SKIPPED);
+    // Delivers the silent master, never the (failed) muxed file.
+    expect(downloadCalls).toEqual([MASTER]);
+    expect(saveVideo).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not run the music step or deliver when the render fails", async () => {
+    const { execute, saveVideo, executeCommand } = renderSandbox({
+      renderExit: 1,
+    });
+
+    const output = await execute(RENDER_INPUT, EXEC_CTX);
+
+    expect(output.ok).toBe(false);
+    expect(executeCommand).toHaveBeenCalledTimes(1);
+    expect(saveVideo).not.toHaveBeenCalled();
   });
 });

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -8,12 +8,13 @@ import { ToolLoopAgent, type ToolSet } from "ai";
 import { getModel } from "./config/index.ts";
 import { MANIM_SYSTEM_PROMPT } from "./prompts/index.ts";
 import { createTools } from "./tools/index.ts";
-import type { SaveVideo } from "./tools/manim.ts";
+import type { BackgroundMusicUrl, SaveVideo } from "./tools/manim.ts";
 
 export function createManimAgent(deps: {
   sandbox: Sandbox;
   conversationId: string;
   saveVideo: SaveVideo;
+  backgroundMusicUrl: BackgroundMusicUrl;
 }): ToolLoopAgent<never, ToolSet, never> {
   return new ToolLoopAgent({
     model: getModel(),

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -3,5 +3,5 @@
 // biome-ignore lint/performance/noBarrelFile: this is the package's public entry, not an internal re-export
 export { createManimAgent } from "./agent.ts";
 export { destroySandbox, ensureSandbox } from "./sandbox/index.ts";
-export type { SaveVideo } from "./tools/manim.ts";
+export type { BackgroundMusicUrl, SaveVideo } from "./tools/manim.ts";
 export { generateConversationTitle } from "./utils/conversation-title.ts";

--- a/packages/agent/src/tools/index.ts
+++ b/packages/agent/src/tools/index.ts
@@ -17,12 +17,21 @@ import {
 import type { Sandbox } from "@daytonaio/sdk";
 import { type ToolSet, tool } from "ai";
 import { type ExaClient, fetchWeb, getExaClient, searchWeb } from "./exa.ts";
-import { createManimTools, type SaveVideo } from "./manim.ts";
+import {
+  type BackgroundMusicUrl,
+  createManimTools,
+  type SaveVideo,
+} from "./manim.ts";
 
 interface ToolDependencies {
   getExaClient?: () => ExaClient;
   /** When present, the agent gets the Manim sandbox tools bound to this turn. */
-  manim?: { sandbox: Sandbox; conversationId: string; saveVideo: SaveVideo };
+  manim?: {
+    sandbox: Sandbox;
+    conversationId: string;
+    saveVideo: SaveVideo;
+    backgroundMusicUrl: BackgroundMusicUrl;
+  };
 }
 
 export function createTools(dependencies: ToolDependencies = {}): ToolSet {

--- a/packages/agent/src/tools/manim.ts
+++ b/packages/agent/src/tools/manim.ts
@@ -25,6 +25,11 @@ const QUALITY_DIR = { low: "480p15", high: "1080p60" } as const;
 const FILE_READY = /File ready at\s+'?([^'\n]+\.mp4)'?/;
 const DIR_PREFIX = /^.*\//;
 const PY_SUFFIX = /\.py$/;
+const MP4_SUFFIX = /\.mp4$/;
+/** Where the fetched background track is staged in the sandbox before muxing. */
+const MUSIC_TRACK = `${PROJECT_DIR}/.background-music.mp3`;
+const MUSIC_VOLUME = 0.15;
+const MUSIC_FADE_IN_SEC = 2;
 
 /** Persist a rendered video and return its storage key (an R2 object key the
  * web resolves to a presigned URL). Implemented by the API. */
@@ -33,6 +38,11 @@ export type SaveVideo = (input: {
   conversationId: string;
   scene: string;
 }) => Promise<string>;
+
+/** A presigned URL the sandbox downloads the background track from (straight
+ * from R2, no byte round-trip through the API). Implemented by the API so the
+ * track can change without a sandbox rebuild. */
+export type BackgroundMusicUrl = () => Promise<string>;
 
 function resolvePath(path: string): string {
   return path.startsWith("/") ? path : `${PROJECT_DIR}/${path}`;
@@ -78,12 +88,48 @@ function outputPath(
   return `${PROJECT_DIR}/media/videos/${stem}/${QUALITY_DIR[quality]}/${scene}.mp4`;
 }
 
+/** Download the background track from R2 into the sandbox (via a presigned URL,
+ * no byte round-trip through the API) and mux it under the silent rendered master
+ * with ffmpeg (looped, ducked, faded in). Returns the path to deliver — the muxed
+ * file on success, or the silent master if the track is missing or anything in
+ * the step fails, so background music never blocks delivery. */
+async function muxBackgroundMusic(
+  sandbox: Sandbox,
+  masterPath: string,
+  backgroundMusicUrl: BackgroundMusicUrl
+): Promise<{ deliverPath: string; note?: string }> {
+  const url = await backgroundMusicUrl();
+  const finalPath = masterPath.replace(MP4_SUFFIX, ".music.mp4");
+  // Download then mux in one shell step; the URL rides in the env (not the
+  // command string) so its signature query params can't break quoting. A
+  // missing object 404s the download, short-circuiting before ffmpeg.
+  const command =
+    `python3 -c "import os,urllib.request; urllib.request.urlretrieve(os.environ['MUSIC_URL'], '${MUSIC_TRACK}')" && ` +
+    `ffmpeg -y -i ${masterPath} -stream_loop -1 -i ${MUSIC_TRACK} ` +
+    `-filter_complex "[1:a]volume=${MUSIC_VOLUME},afade=t=in:st=0:d=${MUSIC_FADE_IN_SEC}[a]" ` +
+    `-map 0:v:0 -map "[a]" -shortest -c:v copy -c:a aac ${finalPath} 2>&1`;
+  const res = await sandbox.process.executeCommand(
+    command,
+    PROJECT_DIR,
+    { MUSIC_URL: url },
+    COMMAND_TIMEOUT_SEC
+  );
+  if (res.exitCode === 0) {
+    return { deliverPath: finalPath };
+  }
+  return {
+    deliverPath: masterPath,
+    note: `[animus] background music skipped (download or mux failed, exit ${res.exitCode}); delivering the silent video.`,
+  };
+}
+
 export function createManimTools(deps: {
   sandbox: Sandbox;
   conversationId: string;
   saveVideo: SaveVideo;
+  backgroundMusicUrl: BackgroundMusicUrl;
 }): ToolSet {
-  const { sandbox, conversationId, saveVideo } = deps;
+  const { sandbox, conversationId, saveVideo, backgroundMusicUrl } = deps;
 
   return {
     writeFile: tool({
@@ -191,22 +237,35 @@ export function createManimTools(deps: {
           return { ok: false, file, scene, exitCode: res.exitCode, logs };
         }
 
-        const path = outputPath(output, file, scene, quality);
+        const masterPath = outputPath(output, file, scene, quality);
+        const { deliverPath, note } = await muxBackgroundMusic(
+          sandbox,
+          masterPath,
+          backgroundMusicUrl
+        );
+        const deliveredLogs = note ? `${logs}\n\n${note}` : logs;
         try {
-          const buffer = await sandbox.fs.downloadFile(path);
+          const buffer = await sandbox.fs.downloadFile(deliverPath);
           const videoKey = await saveVideo({
             bytes: new Uint8Array(buffer),
             conversationId,
             scene,
           });
-          return { ok: true, file, scene, exitCode: 0, videoKey, logs };
+          return {
+            ok: true,
+            file,
+            scene,
+            exitCode: 0,
+            videoKey,
+            logs: deliveredLogs,
+          };
         } catch (error) {
           return {
             ok: false,
             file,
             scene,
             exitCode: 0,
-            logs: `${logs}\n\n[animus] Render reported success but the output at ${path} could not be retrieved: ${String(error)}`,
+            logs: `${logs}\n\n[animus] Render reported success but the output at ${deliverPath} could not be retrieved: ${String(error)}`,
           };
         }
       },


### PR DESCRIPTION
## What this does

Adds a background music bed under every rendered video, muxed automatically inside `renderScene`. Verified working end-to-end.

### Flow
1. `renderScene` renders the silent master as before.
2. The API mints a **presigned GET URL** for the track (`backgroundMusicUrl`) — it never moves the bytes itself.
3. The **sandbox downloads the track straight from R2** and muxes it with ffmpeg in one shell step: `python3 urlretrieve && ffmpeg …` (looped, ducked to 15%, faded in, `-shortest`). The presigned URL rides in the command's **env**, so its signature query params can't break shell quoting.
4. The muxed mp4 is uploaded to R2 and delivered as usual.

### Robust by default
Any failure — missing object (404 on download), ffmpeg error — falls back to delivering the **silent master**, with a note in the logs. Music never blocks delivery.

### Design notes
- **No agent involvement, no prompt change** — music is automatic.
- **No snapshot bake / no rebuild** — the track lives only in R2 (`music/The_Merchants_Of_Death.mp3`), read per render, so swapping it takes effect immediately. Hardcoded key for now; user-configurable is a later iteration.
- The API↔sandbox byte round-trip was avoided on purpose: the API signs, the sandbox pulls.

## Config
- Track object in R2: `music/The_Merchants_Of_Death.mp3` (same `animus-videos` bucket). No new env.

## Tests
Agent: in-sandbox download+mux delivers the muxed file (URL carried in env), silent fallback when the music step fails, no music step when the render itself fails. API: `backgroundMusicUrl` presigns the correct key. Full gate green — typecheck, ultracite, knip, 90 tests.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds background music to all rendered videos by muxing a track in the sandbox after render. If the music step fails, we deliver the silent video so delivery is never blocked.

- New Features
  - API: `backgroundMusicUrl()` presigns a GET for `music/The_Merchants_Of_Death.mp3` in R2 (fixed key for now).
  - Agent/sandbox: downloads the track directly from R2 and muxes with ffmpeg (looped, 15% volume, 2s fade-in, `-shortest`); URL is passed via env to avoid quoting issues; no API byte round-trip.
  - Robustness: on 404 or ffmpeg error, skip music and upload the silent master; logs note the skip.

<sup>Written for commit 1ff501f28dfb5ffe2e0be993e69d96ec06016e69. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/KacemMathlouthi/animus/pull/13?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

