### PR TITLE
feat(api): deploy the API on Vercel — serverless entry alongside the Bun server

### DIFF
--- a/apps/api/api/index.ts
+++ b/apps/api/api/index.ts
@@ -1,0 +1,18 @@
+/** Vercel serverless entry: hands the Hono app to Vercel's Node runtime as a
+ * Web-standard Request→Response handler. Used ONLY on Vercel — local and
+ * container runs go through ../src/server.ts (the Bun process).
+ *
+ * NOTE: maxDuration is pinned to the Hobby-plan ceiling (300s). A chat turn whose
+ * render/repair loop streams past 5 minutes is terminated by the platform with a
+ * 504. That is a known limitation of hosting the streaming API on serverless;
+ * the container entry (src/server.ts) has no such cap. */
+
+import { app } from "../src/app.ts";
+
+export const config = { maxDuration: 300 };
+
+export default function handler(
+  request: Request
+): Response | Promise<Response> {
+  return app.fetch(request);
+}

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -4,8 +4,8 @@
   "version": "0.0.1",
   "type": "module",
   "scripts": {
-    "dev": "bun --watch --env-file=../../.env src/app.ts",
-    "start": "bun --env-file=../../.env src/app.ts",
+    "dev": "bun --watch --env-file=../../.env src/server.ts",
+    "start": "bun --env-file=../../.env src/server.ts",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -4,7 +4,6 @@ import { auth } from "@animus/auth";
 import { getServerEnv } from "@animus/core/env";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
-import { logger } from "./lib/logger.ts";
 import { sessionMiddleware } from "./middleware/auth.ts";
 import { onError, onNotFound } from "./middleware/error.ts";
 import { requestLogger } from "./middleware/logger.ts";
@@ -57,20 +56,3 @@ app.route("/api/chat", chatRoute);
 app.route("/api/media", mediaRoute);
 // Public (unauthenticated) — anyone with an unlisted token can resolve a share.
 app.route("/api/share", shareRoute);
-
-export type AppType = typeof app;
-
-logger.info(`animus-api listening on http://localhost:${env.port}`);
-
-export default {
-  port: env.port,
-  fetch(
-    request: Request,
-    server: Bun.Server<unknown>
-  ): Response | Promise<Response> {
-    if (new URL(request.url).pathname.startsWith("/api/chat")) {
-      server.timeout(request, 0);
-    }
-    return app.fetch(request);
-  },
-};

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -1,0 +1,25 @@
+/** Bun server entry: runs the Hono app as a long-lived process for local dev and
+ * container hosts (Railway/DO/App Runner). Disables the idle timeout on the
+ * streaming chat route so a turn can hold its SSE connection open for the full
+ * render/repair loop — a Bun-native capability serverless platforms lack. */
+
+import { getServerEnv } from "@animus/core/env";
+import { app } from "./app.ts";
+import { logger } from "./lib/logger.ts";
+
+const env = getServerEnv();
+
+logger.info(`animus-api listening on http://localhost:${env.port}`);
+
+export default {
+  port: env.port,
+  fetch(
+    request: Request,
+    server: Bun.Server<unknown>
+  ): Response | Promise<Response> {
+    if (new URL(request.url).pathname.startsWith("/api/chat")) {
+      server.timeout(request, 0);
+    }
+    return app.fetch(request);
+  },
+};

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -3,7 +3,14 @@
   "compilerOptions": {
     "allowImportingTsExtensions": true,
     "declaration": false,
-    "declarationMap": false
+    "declarationMap": false,
+    // Pinned explicitly (not just inherited) so the CJS `export =` packages
+    // (pino, pino-pretty, postgres) and default imports keep resolving under
+    // Vercel's function compiler, which does not honor the inherited value.
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true
   },
-  "include": ["src"]
+  // `api/` holds the Vercel serverless entry; include it so `tsc --noEmit`
+  // type-checks it (it imports ../src/app.ts) instead of silently skipping it.
+  "include": ["src", "api"]
 }

--- a/apps/api/vercel.json
+++ b/apps/api/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "rewrites": [{ "source": "/(.*)", "destination": "/api" }]
+}

--- a/packages/agent/src/tools/exa.ts
+++ b/packages/agent/src/tools/exa.ts
@@ -6,8 +6,9 @@ import type {
   WebSearchInput,
   WebSearchOutput,
 } from "@animus/core/tools";
-import Exa, {
+import {
   type ContentsOptions,
+  Exa,
   type RegularSearchOptions,
   type SearchResponse,
 } from "exa-js";


### PR DESCRIPTION
## What & why

Enables `apps/api` to deploy on Vercel without giving up the Bun long-running server used locally and on container hosts. The current entry (`src/app.ts`) is a Bun server (`export default { fetch(req, server: Bun.Server) { server.timeout(...) } }`), which Vercel can't compile — that's the `Cannot find namespace 'Bun'` build failure.

The fix is a clean split: **one codebase, two entries.**

## Changes

- **`src/app.ts`** → pure Hono. Removed the Bun default export, its now-unused `logger` import, and the unreferenced `AppType` export (surfaced by knip once `app.ts` stopped being the entry).
- **`src/server.ts`** *(new)* → the Bun process entry. Keeps `server.timeout(request, 0)` so a chat turn can hold its SSE stream open for the full render/repair loop. Used by local dev and container hosts (Railway/DO/App Runner).
- **`api/index.ts`** *(new)* → a Web-standard `Request → Response` handler that hands the Hono app to Vercel's Node runtime, pinned to the Hobby-plan `maxDuration` ceiling (300s).
- **`vercel.json`** *(new)* → routes all traffic to the function.
- **`package.json`** → `dev`/`start` now run `src/server.ts`.

## Known limitation (documented in `api/index.ts`)

On Vercel (serverless), a turn whose render/repair loop streams past **300s** is terminated by the platform with a 504 — `renderScene` alone has a 600s timeout, so long turns will be cut. This is an accepted trade-off to ship now; the container entry (`src/server.ts`) has no such cap and is the path for full render loops later.

## Follow-ups (not in this PR)

- Pooled Postgres URL for serverless (connection-per-instance).
- Cross-origin auth cookies → resolved by a same-origin `/api` rewrite on the web project.
- Verify Vercel bundles the source-first `@animus/*` workspace deps.

## Test plan

- `bun run typecheck` — OK
- `bunx ultracite check` — OK
- `bun run knip` — clean
- `bunx vitest run` — 41 files, **329 tests pass** (API suite exercises the named `app` export via `app.request(...)`, unaffected by the split)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deploys `apps/api` on Vercel with a serverless entry while keeping the Bun server for local and container hosts. Fixes the Vercel build error by moving Bun-specific code out of the app entry.

- **New Features**
  - Added `api/index.ts` serverless handler for Vercel (`config.maxDuration: 300`) and `vercel.json` rewrite to `/api`.
  - `src/app.ts` is now a pure Hono app; removed Bun default export and unused exports.
  - Introduced `src/server.ts` as the Bun entry, preserving `server.timeout` for long `/api/chat` SSE; updated `package.json` `dev`/`start` to use it.

- **Migration**
  - Vercel requests over 300s will 504; use the container/Bun entry for full render loops.

<sup>Written for commit 227b609ef5f8d2365389d9238cd5722b821bae5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/KacemMathlouthi/animus/pull/25?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

