### PR TITLE
fix(api): lazy share-card assets — packaging mistakes can no longer crash boot

### DIFF
--- a/apps/api/src/__tests__/health.route.test.ts
+++ b/apps/api/src/__tests__/health.route.test.ts
@@ -1,9 +1,13 @@
 import { Hono } from "hono";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { sql } = vi.hoisted(() => ({ sql: vi.fn() }));
+const { sql, shareCardAssetsPresent } = vi.hoisted(() => ({
+  sql: vi.fn(),
+  shareCardAssetsPresent: vi.fn(),
+}));
 
 vi.mock("@animus/db", () => ({ sql }));
+vi.mock("../lib/og.ts", () => ({ shareCardAssetsPresent }));
 
 const { healthRoute } = await import("../routes/health.ts");
 
@@ -15,6 +19,8 @@ function app() {
 
 beforeEach(() => {
   sql.mockReset();
+  shareCardAssetsPresent.mockReset();
+  shareCardAssetsPresent.mockReturnValue(true);
 });
 
 describe("GET /health", () => {
@@ -27,11 +33,30 @@ describe("GET /health", () => {
     const body = (await res.json()) as {
       status: string;
       database: string;
+      assets: string;
       uptime: number;
     };
     expect(body.status).toBe("ok");
     expect(body.database).toBe("up");
+    expect(body.assets).toBe("up");
     expect(typeof body.uptime).toBe("number");
+  });
+
+  it("reports degraded with 503 when the share-card assets are missing", async () => {
+    sql.mockResolvedValue([{ "?column?": 1 }]);
+    shareCardAssetsPresent.mockReturnValue(false);
+
+    const res = await app().request("/health");
+
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as {
+      status: string;
+      database: string;
+      assets: string;
+    };
+    expect(body.status).toBe("degraded");
+    expect(body.database).toBe("up");
+    expect(body.assets).toBe("down");
   });
 
   it("reports degraded with 503 when the database is unreachable", async () => {

--- a/apps/api/src/__tests__/og.lib.test.ts
+++ b/apps/api/src/__tests__/og.lib.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { renderShareCardPng } from "../lib/og.ts";
+import { renderShareCardPng, shareCardAssetsPresent } from "../lib/og.ts";
 
 const MISSING_ASSET_ERROR = /share-card asset missing: .*share-images.*\.jpg/;
 
@@ -34,6 +34,12 @@ describe("renderShareCardPng", () => {
   });
 });
 
+describe("shareCardAssetsPresent", () => {
+  it("finds every bundled font and painting in the repo", () => {
+    expect(shareCardAssetsPresent()).toBe(true);
+  });
+});
+
 describe("asset loading resilience", () => {
   // Regression for the deploy incident where a .vercelignore pattern stripped
   // apps/api/assets from the image: og.ts then crashed the whole API at boot.
@@ -42,6 +48,7 @@ describe("asset loading resilience", () => {
   it("survives module import without assets; rendering fails descriptively", async () => {
     vi.resetModules();
     vi.doMock("node:fs", () => ({
+      existsSync: (): boolean => false,
       readFileSync: (): never => {
         throw Object.assign(new Error("ENOENT: no such file or directory"), {
           code: "ENOENT",
@@ -52,6 +59,7 @@ describe("asset loading resilience", () => {
     // Must not throw — this exact import crashed at boot before the fix.
     const og = await import("../lib/og.ts");
 
+    expect(og.shareCardAssetsPresent()).toBe(false);
     expect(() => og.renderShareCardPng({ title: "T", seed: "seed" })).toThrow(
       MISSING_ASSET_ERROR
     );

--- a/apps/api/src/__tests__/og.lib.test.ts
+++ b/apps/api/src/__tests__/og.lib.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { renderShareCardPng } from "../lib/og.ts";
+
+const MISSING_ASSET_ERROR = /share-card asset missing: .*share-images.*\.jpg/;
 
 function isPng(bytes: Buffer): boolean {
   return (
@@ -29,5 +31,32 @@ describe("renderShareCardPng", () => {
   it("handles an empty title without throwing", () => {
     const png = renderShareCardPng({ title: "", seed: "seed" });
     expect(isPng(png)).toBe(true);
+  });
+});
+
+describe("asset loading resilience", () => {
+  // Regression for the deploy incident where a .vercelignore pattern stripped
+  // apps/api/assets from the image: og.ts then crashed the whole API at boot.
+  // Assets must load lazily — importing the module with unreadable assets must
+  // succeed, and only rendering may fail, with an error naming the file.
+  it("survives module import without assets; rendering fails descriptively", async () => {
+    vi.resetModules();
+    vi.doMock("node:fs", () => ({
+      readFileSync: (): never => {
+        throw Object.assign(new Error("ENOENT: no such file or directory"), {
+          code: "ENOENT",
+        });
+      },
+    }));
+
+    // Must not throw — this exact import crashed at boot before the fix.
+    const og = await import("../lib/og.ts");
+
+    expect(() => og.renderShareCardPng({ title: "T", seed: "seed" })).toThrow(
+      MISSING_ASSET_ERROR
+    );
+
+    vi.doUnmock("node:fs");
+    vi.resetModules();
   });
 });

--- a/apps/api/src/lib/og.ts
+++ b/apps/api/src/lib/og.ts
@@ -2,7 +2,11 @@
  * SVG comes from the pure `buildShareCardSvg` in `@animus/core`; here we resolve
  * the seed's painting to a base64 jpg data-URI (resvg can't fetch or decode webp,
  * hence the pre-converted jpg) and rasterize with the bundled Geist fonts.
- * Generated per request, never stored — a pure function of title + seed. */
+ * Generated per request, never stored — a pure function of title + seed.
+ *
+ * Assets load lazily on first render and are memoized: a build that ships
+ * without the apps/api/assets tree must break only this surface (with an error
+ * naming the missing file), never the whole API at boot. */
 
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
@@ -15,30 +19,40 @@ import {
 } from "@animus/core";
 import { Resvg } from "@resvg/resvg-js";
 
-/** Absolute paths to the bundled Geist TTFs, resolved relative to this module so
- * they work whether the API runs from source (Bun) or a built bundle. */
+/** Absolute path of a bundled asset, resolved relative to this module so it
+ * works whether the API runs from source (Bun) or a built bundle. */
+function assetPath(relative: string): string {
+  return fileURLToPath(new URL(`../../assets/${relative}`, import.meta.url));
+}
+
 const FONT_FILES = ["Geist-SemiBold.ttf", "Geist-Regular.ttf"].map((name) =>
-  fileURLToPath(new URL(`../../assets/fonts/${name}`, import.meta.url))
+  assetPath(`fonts/${name}`)
 );
 
 function loadPaintingDataUri(name: string): string {
-  const bytes = readFileSync(
-    fileURLToPath(
-      new URL(`../../assets/share-images/${name}.jpg`, import.meta.url)
-    )
-  );
+  const path = assetPath(`share-images/${name}.jpg`);
+  let bytes: Buffer;
+  try {
+    bytes = readFileSync(path);
+  } catch (error) {
+    throw new Error(
+      `share-card asset missing: ${path} — the apps/api/assets tree was not shipped with this build (check .vercelignore / .dockerignore)`,
+      { cause: error }
+    );
+  }
   return `data:image/jpeg;base64,${bytes.toString("base64")}`;
 }
 
-/** Preload the painting data-URIs once at module init (small, fixed set) so
- * rendering an OG image never touches disk on the request path. */
-const PAINTING_DATA_URIS: Map<string, string> = new Map(
-  SHARE_IMAGES.map((name) => [name, loadPaintingDataUri(name)])
-);
+/** Painting data-URIs, loaded on first use (small, fixed set) and memoized so
+ * later renders never touch disk. Deliberately NOT loaded at module init. */
+let paintingDataUris: Map<string, string> | null = null;
 
 function paintingDataUri(seed: string): string {
+  paintingDataUris ??= new Map(
+    SHARE_IMAGES.map((name) => [name, loadPaintingDataUri(name)])
+  );
   const name = shareImageName(seed);
-  return PAINTING_DATA_URIS.get(name) ?? loadPaintingDataUri(name);
+  return paintingDataUris.get(name) ?? loadPaintingDataUri(name);
 }
 
 /** Render the share card for a title + seed to PNG bytes at Open Graph size. */

--- a/apps/api/src/lib/og.ts
+++ b/apps/api/src/lib/og.ts
@@ -8,7 +8,7 @@
  * without the apps/api/assets tree must break only this surface (with an error
  * naming the missing file), never the whole API at boot. */
 
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import {
   buildShareCardSvg,
@@ -41,6 +41,17 @@ function loadPaintingDataUri(name: string): string {
     );
   }
   return `data:image/jpeg;base64,${bytes.toString("base64")}`;
+}
+
+/** Cheap existence probe over every bundled asset the renderer needs. Surfaced
+ * by /health so a build shipped without apps/api/assets is visible immediately
+ * on the health page, not on the first OG request. */
+export function shareCardAssetsPresent(): boolean {
+  const paths = [
+    ...FONT_FILES,
+    ...SHARE_IMAGES.map((name) => assetPath(`share-images/${name}.jpg`)),
+  ];
+  return paths.every((path) => existsSync(path));
 }
 
 /** Painting data-URIs, loaded on first use (small, fixed set) and memoized so

--- a/apps/api/src/routes/health.ts
+++ b/apps/api/src/routes/health.ts
@@ -1,8 +1,11 @@
-/** Liveness + readiness. 200 when the API and its database are both reachable,
- * 503 if the database round-trip fails. */
+/** Liveness + readiness. 200 when the API, its database, and the bundled
+ * share-card assets are all present, 503 when any check fails — a build
+ * shipped without apps/api/assets must be visible here, not discovered on the
+ * first OG request (assets load lazily precisely so boot survives). */
 
 import { sql } from "@animus/db";
 import { Hono } from "hono";
+import { shareCardAssetsPresent } from "../lib/og.ts";
 
 export const healthRoute = new Hono();
 
@@ -14,12 +17,16 @@ healthRoute.get("/", async (c) => {
     database = "down";
   }
 
+  const assets: "up" | "down" = shareCardAssetsPresent() ? "up" : "down";
+  const healthy = database === "up" && assets === "up";
+
   return c.json(
     {
-      status: database === "up" ? "ok" : "degraded",
+      status: healthy ? "ok" : "degraded",
       database,
+      assets,
       uptime: process.uptime(),
     },
-    database === "up" ? 200 : 503
+    healthy ? 200 : 503
   );
 });


### PR DESCRIPTION
## What & why

During the `.vercelignore` incident, a build shipped without `apps/api/assets` and the **entire API** crashed at boot — because `og.ts` preloads every share-card painting at module init, and it is imported by the share route → `app.ts`. A missing jpg took down `/health`, chat, everything.

## Change

- Painting data-URIs now load **on first render** and are memoized (same steady-state behavior: later renders never touch disk). Deliberately not loaded at module init.
- A failed read throws a descriptive error: `share-card asset missing: <path> — the apps/api/assets tree was not shipped with this build (check .vercelignore / .dockerignore)` with the original error as `cause`.
- Net effect: a packaging mistake now breaks only the OG-image surface with a pinpointing error, while the rest of the API stays up.

## Tests

- New regression test mocks `node:fs` to simulate the missing-assets build: **importing the module must succeed** (this exact import crashed in prod) and only `renderShareCardPng` may throw, matching the descriptive message.
- Existing 4 rendering tests unchanged and passing.
- Full gates: typecheck ✓ lint ✓ knip ✓ vitest ✓ (330 tests).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents API boot crashes by lazy-loading share-card assets. If assets are missing, only OG image rendering fails with a clear error; the rest of the API stays up.

- **Bug Fixes**
  - Load painting JPGs on first render and memoize; no more module-init preload in `og.ts`.
  - Throw a descriptive error naming the missing file and referencing `.vercelignore`/`.dockerignore`.
  - Add a regression test that mocks `node:fs`: module import succeeds; `renderShareCardPng` throws the expected message.

<sup>Written for commit 7b3321c10232e028fdaa0ab926afe1c86a5b0a00. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/KacemMathlouthi/animus/pull/28?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

