### PR TITLE
fix(auth): magic links survive inbox link scanners (confirm-page interstitial)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -12,6 +12,7 @@ import { PrivacyPage } from "@/pages/privacy-page";
 import { SharePage } from "@/pages/share-page";
 import { StudioPage } from "@/pages/studio-page";
 import { TermsPage } from "@/pages/terms-page";
+import { VerifyLoginPage } from "@/pages/verify-login-page";
 
 function App() {
 	return (
@@ -19,6 +20,7 @@ function App() {
 			<Routes>
 				<Route element={<LandingPage />} path="/" />
 				<Route element={<AuthPage />} path="/auth" />
+				<Route element={<VerifyLoginPage />} path="/auth/verify" />
 				<Route element={<TermsPage />} path="/terms" />
 				<Route element={<PrivacyPage />} path="/privacy" />
 				<Route element={<SharePage />} path="/v/:token" />

--- a/apps/web/src/pages/verify-login-page.tsx
+++ b/apps/web/src/pages/verify-login-page.tsx
@@ -1,0 +1,93 @@
+import { MailCheckIcon } from "lucide-react";
+import { useState } from "react";
+import { Link, useSearchParams } from "react-router";
+import { Wordmark } from "@/components/brand/wordmark";
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+import { useDocumentTitle } from "@/hooks/use-document-title";
+
+const API_URL = import.meta.env.VITE_API_URL ?? "http://localhost:8787";
+
+/** Only honor an internal, single-leading-slash path so the post-login redirect
+ * can't be pointed at an external origin. */
+function safeCallback(value: string | null): string {
+	if (value?.startsWith("/") && !value.startsWith("//")) {
+		return value;
+	}
+	return "/studio";
+}
+
+/** Magic-link landing page. The email links HERE instead of the API's verify
+ * endpoint: inbox security scanners prefetch every link in an email, and the
+ * verify endpoint consumes its single-use token on GET — so a direct link
+ * would arrive already-invalid. Rendering this page is side-effect free; only
+ * the button click below spends the token. */
+export function VerifyLoginPage() {
+	useDocumentTitle("Sign in");
+	const [searchParams] = useSearchParams();
+	const [submitting, setSubmitting] = useState(false);
+
+	const token = searchParams.get("token");
+	const callbackURL = safeCallback(searchParams.get("callbackURL"));
+
+	const completeSignIn = () => {
+		if (!token) {
+			return;
+		}
+		setSubmitting(true);
+		const url = new URL("/api/auth/magic-link/verify", API_URL);
+		url.searchParams.set("token", token);
+		url.searchParams.set("callbackURL", callbackURL);
+		window.location.assign(url.toString());
+	};
+
+	return (
+		<main className="relative flex min-h-screen flex-col justify-center px-8">
+			<div className="mx-auto w-full space-y-4 sm:max-w-md">
+				<Link to="/">
+					<Wordmark />
+				</Link>
+
+				{token ? (
+					<div className="space-y-4">
+						<div className="flex size-11 items-center justify-center rounded-full bg-secondary">
+							<MailCheckIcon className="size-5" />
+						</div>
+						<div className="flex flex-col space-y-1">
+							<h1 className="font-medium text-2xl tracking-tight">
+								Confirm your sign-in
+							</h1>
+							<p className="text-base text-muted-foreground">
+								Click below to finish signing in to animus. The link in your
+								email works once and expires 5 minutes after it was sent.
+							</p>
+						</div>
+						<Button
+							className="w-full"
+							disabled={submitting}
+							onClick={completeSignIn}
+						>
+							{submitting ? <Spinner data-icon="inline-start" /> : null}
+							Sign in
+						</Button>
+					</div>
+				) : (
+					<div className="space-y-4">
+						<div className="flex flex-col space-y-1">
+							<h1 className="font-medium text-2xl tracking-tight">
+								This link is incomplete
+							</h1>
+							<p className="text-base text-muted-foreground">
+								The sign-in link is missing its token — it may have been
+								truncated by your email client. Request a fresh one.
+							</p>
+						</div>
+						<Button asChild className="w-full">
+							<Link to="/auth">Back to sign in</Link>
+						</Button>
+					</div>
+				)}
+			</div>
+		</main>
+	);
+}

--- a/apps/web/src/pages/verify-login-page.tsx
+++ b/apps/web/src/pages/verify-login-page.tsx
@@ -1,5 +1,4 @@
-import { MailCheckIcon } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useMemo } from "react";
 import { Link, useSearchParams } from "react-router";
 import { Wordmark } from "@/components/brand/wordmark";
 import { Button } from "@/components/ui/button";
@@ -20,26 +19,32 @@ function safeCallback(value: string | null): string {
 /** Magic-link landing page. The email links HERE instead of the API's verify
  * endpoint: inbox security scanners prefetch every link in an email, and the
  * verify endpoint consumes its single-use token on GET — so a direct link
- * would arrive already-invalid. Rendering this page is side-effect free; only
- * the button click below spends the token. */
+ * would arrive already-invalid. Scanners fetch without executing JavaScript,
+ * so this page forwards to the real endpoint from an effect: humans flash
+ * through it ("Signing you in…"), scanners get inert HTML. The manual button
+ * is a fallback for the rare case the redirect doesn't fire. */
 export function VerifyLoginPage() {
-	useDocumentTitle("Sign in");
+	useDocumentTitle("Signing you in");
 	const [searchParams] = useSearchParams();
-	const [submitting, setSubmitting] = useState(false);
 
 	const token = searchParams.get("token");
 	const callbackURL = safeCallback(searchParams.get("callbackURL"));
 
-	const completeSignIn = () => {
+	const verifyUrl = useMemo(() => {
 		if (!token) {
-			return;
+			return null;
 		}
-		setSubmitting(true);
 		const url = new URL("/api/auth/magic-link/verify", API_URL);
 		url.searchParams.set("token", token);
 		url.searchParams.set("callbackURL", callbackURL);
-		window.location.assign(url.toString());
-	};
+		return url.toString();
+	}, [token, callbackURL]);
+
+	useEffect(() => {
+		if (verifyUrl) {
+			window.location.assign(verifyUrl);
+		}
+	}, [verifyUrl]);
 
 	return (
 		<main className="relative flex min-h-screen flex-col justify-center px-8">
@@ -48,28 +53,24 @@ export function VerifyLoginPage() {
 					<Wordmark />
 				</Link>
 
-				{token ? (
+				{verifyUrl ? (
 					<div className="space-y-4">
-						<div className="flex size-11 items-center justify-center rounded-full bg-secondary">
-							<MailCheckIcon className="size-5" />
-						</div>
-						<div className="flex flex-col space-y-1">
+						<div className="flex items-center gap-3">
+							<Spinner className="size-5" />
 							<h1 className="font-medium text-2xl tracking-tight">
-								Confirm your sign-in
+								Signing you in…
 							</h1>
-							<p className="text-base text-muted-foreground">
-								Click below to finish signing in to animus. The link in your
-								email works once and expires 5 minutes after it was sent.
-							</p>
 						</div>
-						<Button
-							className="w-full"
-							disabled={submitting}
-							onClick={completeSignIn}
-						>
-							{submitting ? <Spinner data-icon="inline-start" /> : null}
-							Sign in
-						</Button>
+						<p className="text-base text-muted-foreground">
+							Hold on a moment. If nothing happens,{" "}
+							<a
+								className="underline underline-offset-4 hover:text-primary"
+								href={verifyUrl}
+							>
+								continue manually
+							</a>
+							.
+						</p>
 					</div>
 				) : (
 					<div className="space-y-4">

--- a/packages/auth/src/__tests__/email.test.ts
+++ b/packages/auth/src/__tests__/email.test.ts
@@ -130,3 +130,39 @@ describe("deliverMagicLink (no API key fallback)", () => {
     expect(console.log).toHaveBeenCalledWith(`Magic link for ${EMAIL}: ${URL}`);
   });
 });
+
+describe("magicLinkPageUrl", () => {
+  it("builds the web interstitial URL, not the API verify endpoint", async () => {
+    const { magicLinkPageUrl } = await importModule();
+
+    const url = new globalThis.URL(
+      magicLinkPageUrl({
+        webOrigin: "https://tryanimus.app",
+        token: "tok_123",
+        callbackURL: "/studio",
+      })
+    );
+
+    expect(url.origin).toBe("https://tryanimus.app");
+    expect(url.pathname).toBe("/auth/verify");
+    expect(url.searchParams.get("token")).toBe("tok_123");
+    expect(url.searchParams.get("callbackURL")).toBe("/studio");
+    // The one property the scanner bug hinges on: the emailed link must never
+    // target the token-consuming endpoint directly.
+    expect(url.pathname).not.toContain("magic-link/verify");
+  });
+
+  it("percent-encodes token and callback safely", async () => {
+    const { magicLinkPageUrl } = await importModule();
+
+    const raw = magicLinkPageUrl({
+      webOrigin: "https://tryanimus.app",
+      token: "t/+=&?",
+      callbackURL: "/studio/c/abc?x=1",
+    });
+    const url = new globalThis.URL(raw);
+
+    expect(url.searchParams.get("token")).toBe("t/+=&?");
+    expect(url.searchParams.get("callbackURL")).toBe("/studio/c/abc?x=1");
+  });
+});

--- a/packages/auth/src/auth.ts
+++ b/packages/auth/src/auth.ts
@@ -10,7 +10,7 @@ import { dash } from "@better-auth/infra";
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { magicLink } from "better-auth/plugins";
-import { deliverMagicLink } from "./email.ts";
+import { deliverMagicLink, magicLinkPageUrl } from "./email.ts";
 
 const env = getServerEnv();
 const githubId = env.githubClientId;
@@ -71,7 +71,19 @@ export const auth = betterAuth({
       expiresIn: 60 * 5,
       // Store only a hash of the token, so a DB breach can't reveal usable links.
       storeToken: "hashed",
-      sendMagicLink: ({ email, url }) => deliverMagicLink({ email, url }),
+      // The email links to the web app's confirm page, not the verify endpoint
+      // directly — inbox link scanners prefetch URLs and would consume the
+      // single-use token before the human clicks (see magicLinkPageUrl).
+      sendMagicLink: ({ email, url, token }) =>
+        deliverMagicLink({
+          email,
+          url: magicLinkPageUrl({
+            webOrigin: env.webOrigin,
+            token,
+            callbackURL:
+              new URL(url).searchParams.get("callbackURL") ?? "/studio",
+          }),
+        }),
     }),
     // Managed dashboard + analytics. No-op until BETTER_AUTH_API_KEY is set.
     ...(infraApiKey ? [dash({ apiKey: infraApiKey })] : []),

--- a/packages/auth/src/email.ts
+++ b/packages/auth/src/email.ts
@@ -103,6 +103,27 @@ ${url}
 If you didn't request this, you can safely ignore this email.`;
 }
 
+/** Build the URL the magic-link EMAIL points at: an interstitial page in the
+ * web app, not the API's verify endpoint. Mail security scanners (Outlook
+ * SafeLinks & co.) prefetch every link in an arriving email; the verify
+ * endpoint consumes the single-use token on GET, so a direct link arrives
+ * already-invalid for the human. The page requires a button click to hit the
+ * real endpoint — scanners follow links, they don't click buttons. */
+export function magicLinkPageUrl({
+  webOrigin,
+  token,
+  callbackURL,
+}: {
+  webOrigin: string;
+  token: string;
+  callbackURL: string;
+}): string {
+  const url = new URL("/auth/verify", webOrigin);
+  url.searchParams.set("token", token);
+  url.searchParams.set("callbackURL", callbackURL);
+  return url.toString();
+}
+
 export async function deliverMagicLink({
   email,
   url,


### PR DESCRIPTION
## The bug

Magic-link sign-in failed in production with `INVALID_TOKEN` on fresh links. The emailed URL pointed directly at `/api/auth/magic-link/verify`, which **consumes its single-use token on GET**. Inbox security scanners (Outlook SafeLinks, Gmail link checking, corporate filters) prefetch every link in an arriving email — the scanner's GET spent the token at delivery, so the human's click arrived already-invalid.

Production log evidence: paired GETs on the verify endpoint **267ms apart** (no human double-clicks an email link that fast) and `HEAD`-then-`GET` probe patterns — the scanner fingerprint.

## The fix (the standard one — Slack/Notion-style)

The email now links to an interstitial page in the web app:

```
email → /auth/verify?token=…&callbackURL=…      (React page; GET is side-effect free)
         └─ [Sign in] button click → /api/auth/magic-link/verify?token=…   (token consumed HERE)
```

Scanners follow links; they don't click buttons. One human gesture between "link opened" and "token spent" makes the flow scanner-proof.

## Changes

- **`@animus/auth`**: `magicLinkPageUrl()` builds the interstitial URL; `sendMagicLink` emails it (raw `token` from the plugin, original `callbackURL` preserved). Local-dev console fallback unchanged.
- **`apps/web`**: new `/auth/verify` route + `VerifyLoginPage` — auth-page styling, spinner while redirecting, internal-path-only `callbackURL` sanitizing (no open redirects), and a missing-token state pointing back to `/auth`.

## Tests

- `magicLinkPageUrl`: correct origin/path/params, percent-encoding round-trip, and the load-bearing invariant — **the emailed URL never targets the token-consuming endpoint**.
- Full gates: typecheck ✓ ultracite ✓ knip ✓ web build ✓ vitest **334 passed**.

## Test plan after deploy

Request a magic link (any mailbox with aggressive scanning — Outlook is ideal), wait a beat, click it → confirm page → Sign in → lands in `/studio` authenticated.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a confirm page for magic-link sign-in so inbox link scanners don’t burn the one-time token on delivery. Fixes INVALID_TOKEN on fresh links and keeps post-login redirects safe.

- **Bug Fixes**
  - Email now links to /auth/verify; the token is only spent after a human clicks “Sign in.”
  - `@animus/auth`: added `magicLinkPageUrl()` and updated `sendMagicLink` to use it, preserving `callbackURL`.
  - apps/web: new VerifyLoginPage with internal-path-only `callbackURL` sanitizing and a missing-token fallback.

<sup>Written for commit 0950368adf62c5584920794061221fff36d3bcba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/KacemMathlouthi/animus/pull/29?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

