### PR TITLE
fix(api)/refactor(db): chat body zod envelope + env-routed DATABASE_URL

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -26,7 +26,8 @@
     "braintrust": "^3.20.0",
     "hono": "^4.12.25",
     "pino": "^10.3.1",
-    "pino-pretty": "^13.1.3"
+    "pino-pretty": "^13.1.3",
+    "zod": "^4.3.5"
   },
   "devDependencies": {
     "vitest": "^3"

--- a/apps/api/src/__tests__/chat.route.test.ts
+++ b/apps/api/src/__tests__/chat.route.test.ts
@@ -162,6 +162,25 @@ describe("POST /chat — request validation", () => {
     );
     expect(res.status).toBe(400);
   });
+
+  it("400s (not 500) when the body is not JSON at all", async () => {
+    const res = await appWith({ id: "u1" }).request("/chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not-json{",
+    });
+    expect(res.status).toBe(400);
+    expect(loadOwnedConversation).not.toHaveBeenCalled();
+  });
+
+  it("400s when id is not a string, instead of leaking it into queries", async () => {
+    const res = await post(
+      { id: "u1" },
+      { id: 123, message: userMessage("m1", "hi") }
+    );
+    expect(res.status).toBe(400);
+    expect(loadOwnedConversation).not.toHaveBeenCalled();
+  });
 });
 
 describe("POST /chat — ownership", () => {

--- a/apps/api/src/routes/chat.ts
+++ b/apps/api/src/routes/chat.ts
@@ -16,6 +16,7 @@ import { getServerEnv } from "@animus/core/env";
 import { convertToModelMessages, createIdGenerator } from "ai";
 import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
+import { z } from "zod";
 import { backgroundMusicUrl, saveVideo } from "../lib/media.ts";
 import { userId } from "../lib/user.ts";
 import { requireAuth } from "../middleware/auth.ts";
@@ -39,15 +40,24 @@ export const chatRoute = new Hono<AppEnv>();
 
 chatRoute.use("*", requireAuth);
 
-chatRoute.post("/", async (c) => {
-  const body = (await c.req.json().catch(() => null)) as {
-    id?: string;
-    message?: unknown;
-  } | null;
+/** Request envelope: the conversation id plus the newest UI message. The
+ * message's internal shape is checked separately by isUIMessage — here Zod
+ * guarantees the envelope itself, so malformed bodies are a clean 400 instead
+ * of leaking a non-string id into queries (500). */
+const ChatRequestSchema = z.object({
+  id: z.string().min(1),
+  message: z.unknown(),
+});
 
-  if (!(body?.id && isUIMessage(body.message))) {
+chatRoute.post("/", async (c) => {
+  const parsed = ChatRequestSchema.safeParse(
+    await c.req.json().catch(() => null)
+  );
+
+  if (!(parsed.success && isUIMessage(parsed.data.message))) {
     throw new HTTPException(400, { message: "id and message are required" });
   }
+  const body = { id: parsed.data.id, message: parsed.data.message };
   const conversationId = body.id;
   const uid = userId(c);
 

--- a/bun.lock
+++ b/bun.lock
@@ -34,6 +34,7 @@
         "hono": "^4.12.25",
         "pino": "^10.3.1",
         "pino-pretty": "^13.1.3",
+        "zod": "^4.3.5",
       },
       "devDependencies": {
         "vitest": "^3",

--- a/bun.lock
+++ b/bun.lock
@@ -58,8 +58,8 @@
         "@streamdown/mermaid": "^1.0.2",
         "@tailwindcss/vite": "^4",
         "@types/three": "^0.184.1",
-        "@vercel/speed-insights": "^2.0.0",
         "@vercel/analytics": "^2.0.1",
+        "@vercel/speed-insights": "^2.0.0",
         "ai": "^6.0.206",
         "better-auth": "^1.6.19",
         "class-variance-authority": "^0.7.1",
@@ -141,6 +141,7 @@
       "name": "@animus/db",
       "version": "0.0.1",
       "dependencies": {
+        "@animus/core": "workspace:*",
         "drizzle-orm": "^0.45.2",
         "postgres": "^3.4.9",
       },

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -14,6 +14,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@animus/core": "workspace:*",
     "drizzle-orm": "^0.45.2",
     "postgres": "^3.4.9"
   },

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -1,6 +1,9 @@
-/** The Drizzle database client. Reads DATABASE_URL from the environment and
- * binds the full schema so queries are fully typed (db.query.user, etc.). */
+/** The Drizzle database client. Takes DATABASE_URL from the validated server
+ * env (@animus/core/env — the single sanctioned source; runtime code never
+ * reads process.env directly) and binds the full schema so queries are fully
+ * typed (db.query.user, etc.). */
 
+import { getServerEnv } from "@animus/core/env";
 import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 import {
@@ -43,16 +46,8 @@ export const schema = {
   conversationMessageRelations,
 };
 
-const connectionString = process.env.DATABASE_URL;
-
-if (!connectionString) {
-  throw new Error(
-    "DATABASE_URL is not set. Copy .env.example to .env (see the repo root)."
-  );
-}
-
 /** The underlying postgres.js connection. Exposed for graceful shutdown. */
-export const sql = postgres(connectionString);
+export const sql = postgres(getServerEnv().databaseUrl);
 
 export const db = drizzle(sql, { schema });
 


### PR DESCRIPTION
Two of the standing code-quality items from todo.md, one commit each:

## 1. `refactor(db)`: DATABASE_URL via `@animus/core/env`
`packages/db/src/client.ts` was the last runtime module reading `process.env` directly, against the repo's env contract. It now uses `getServerEnv().databaseUrl` — schema-validated at boot, same error surface as every other variable. Adds `@animus/core` as a workspace dep of `packages/db`.

## 2. `fix(api)`: chat request envelope validated with Zod
`POST /api/chat` cast its body with `as`. Malformed JSON already 400'd, but a **non-string `id`** (e.g. `{"id": 123}`) passed the truthiness check and leaked into the conversation query → 500. The envelope is now `z.object({ id: z.string().min(1), message: z.unknown() })`; `isUIMessage` continues to validate the message's internal shape. New tests: non-JSON body → 400, numeric id → 400 (both asserting the DB is never touched).

## Deliberately NOT in this PR
The third todo item (settings `music_track`/`voice_id` nullable-vs-required mismatch) was explored and reverted, including a full rollback of the trial migration on the database — punted for a separate decision.

## Gates
typecheck ✓ ultracite ✓ knip ✓ vitest **336 passed** (2 new)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened chat request validation to return clean 400s instead of 500s, and routed `DATABASE_URL` through the validated server env in `@animus/core` for consistent boot-time checks.

- **Bug Fixes**
  - Validate `POST /api/chat` with Zod: require non-empty string `id` and pass-through `message`; malformed JSON or non-string `id` now 400. `isUIMessage` still checks the message shape. Added tests that assert 400 responses and no DB access.

- **Refactors**
  - Read `DATABASE_URL` via `getServerEnv()` from `@animus/core` (no direct `process.env` reads). Adds `@animus/core` as a workspace dependency and unifies env validation at startup.

<sup>Written for commit 51fdf554044b698b68cb1d65ee1804b9c1a4336c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/KacemMathlouthi/animus/pull/30?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

