### PR TITLE
fix(web): magic-link confirm page requires an explicit click

### DIFF
--- a/apps/web/src/pages/verify-login-page.tsx
+++ b/apps/web/src/pages/verify-login-page.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from "react";
+import { useMemo, useState } from "react";
 import { Link, useSearchParams } from "react-router";
 import { Wordmark } from "@/components/brand/wordmark";
 import { Button } from "@/components/ui/button";
@@ -17,15 +17,16 @@ function safeCallback(value: string | null): string {
 }
 
 /** Magic-link landing page. The email links HERE instead of the API's verify
- * endpoint: inbox security scanners prefetch every link in an email, and the
+ * endpoint: inbox security scanners open every link in an email, and the
  * verify endpoint consumes its single-use token on GET — so a direct link
- * would arrive already-invalid. Scanners fetch without executing JavaScript,
- * so this page forwards to the real endpoint from an effect: humans flash
- * through it ("Signing you in…"), scanners get inert HTML. The manual button
- * is a fallback for the rare case the redirect doesn't fire. */
+ * arrives already-invalid. An auto-redirect variant was tried and defeated in
+ * production: the scanner executed the page's JavaScript (paired verify hits
+ * 134ms apart in the logs). Only a real click may spend the token — scanners
+ * render pages, but they don't press buttons. */
 export function VerifyLoginPage() {
-	useDocumentTitle("Signing you in");
+	useDocumentTitle("Sign in");
 	const [searchParams] = useSearchParams();
+	const [submitting, setSubmitting] = useState(false);
 
 	const token = searchParams.get("token");
 	const callbackURL = safeCallback(searchParams.get("callbackURL"));
@@ -40,11 +41,13 @@ export function VerifyLoginPage() {
 		return url.toString();
 	}, [token, callbackURL]);
 
-	useEffect(() => {
-		if (verifyUrl) {
-			window.location.assign(verifyUrl);
+	const completeSignIn = () => {
+		if (!verifyUrl) {
+			return;
 		}
-	}, [verifyUrl]);
+		setSubmitting(true);
+		window.location.assign(verifyUrl);
+	};
 
 	return (
 		<main className="relative flex min-h-screen flex-col justify-center px-8">
@@ -55,22 +58,22 @@ export function VerifyLoginPage() {
 
 				{verifyUrl ? (
 					<div className="space-y-4">
-						<div className="flex items-center gap-3">
-							<Spinner className="size-5" />
+						<div className="flex flex-col space-y-1">
 							<h1 className="font-medium text-2xl tracking-tight">
-								Signing you in…
+								Confirm your sign-in
 							</h1>
+							<p className="text-base text-muted-foreground">
+								Click below to finish signing in to animus.
+							</p>
 						</div>
-						<p className="text-base text-muted-foreground">
-							Hold on a moment. If nothing happens,{" "}
-							<a
-								className="underline underline-offset-4 hover:text-primary"
-								href={verifyUrl}
-							>
-								continue manually
-							</a>
-							.
-						</p>
+						<Button
+							className="w-full"
+							disabled={submitting}
+							onClick={completeSignIn}
+						>
+							{submitting ? <Spinner data-icon="inline-start" /> : null}
+							Sign in
+						</Button>
 					</div>
 				) : (
 					<div className="space-y-4">


### PR DESCRIPTION
## Why the auto-redirect wasn't enough

PR #29's interstitial auto-forwarded via a `useEffect` — the assumption being that mail scanners fetch HTML without executing JS. Production falsified that: with #29 verifiably deployed (`fe8dc56`), a fresh magic link still died with `INVALID_TOKEN`, and the API logs show the signature — **paired hits on the verify endpoint 134ms apart** ~23s after send, followed by the human's clicks failing. The scanner in this mail chain runs a real browser: it loaded `/auth/verify`, executed the redirect effect, and consumed the token.

## The fix

`window.location.assign` moves from the mount effect into the **Sign in button's click handler**. A scanner can render the page all it wants — nothing happens without a click. This is the strongest variant of the pattern (the one banks use), at the cost of one extra click on sign-in.

## Cost/benefit

- Auto-redirect (one-click feel): defeated by JS-executing scanners — *empirically*, by this user's own mailbox.
- Explicit button (two clicks): immune to every scanner class that exists short of one that synthesizes user gestures.

Reliability wins for an auth flow.

Gates: typecheck ✓ lint ✓ build ✓ (no behavior change server-side; page is client-only).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require an explicit click on the magic-link confirm page to prevent email scanners from consuming single-use tokens. Improves reliability of sign-in at the cost of one extra click.

- **Bug Fixes**
  - Moved redirect from `useEffect` to the Sign in button’s click handler (`window.location.assign`).
  - Added submitting state to disable the button and show a spinner; updated title and copy.
  - No server changes; blocks JS-executing inbox scanners from spending tokens.

<sup>Written for commit bf0a3565f00c6be3ebbf99406b58edbd69c7a480. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/KacemMathlouthi/animus/pull/31?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

