### PR TITLE
fix(agent): explicit Bedrock credentials — Vercel shadows user AWS_* env vars

### DIFF
--- a/packages/agent/src/__tests__/config.test.ts
+++ b/packages/agent/src/__tests__/config.test.ts
@@ -22,9 +22,15 @@ vi.mock("@ai-sdk/google", () => ({
       `google:${model}:${apiKey}`,
 }));
 vi.mock("@animus/core/env", () => ({
-  getServerEnv: () => ({ bedrockModel: "bedrock-default-id" }),
+  getServerEnv: () => ({
+    bedrockModel: "bedrock-default-id",
+    bedrockAccessKeyId: "AKIA_TEST",
+    bedrockSecretAccessKey: "SECRET_TEST",
+    bedrockRegion: "us-east-1",
+  }),
 }));
 
+const { createAmazonBedrock } = await import("@ai-sdk/amazon-bedrock");
 const { getModel, resolveModel } = await import("../config/index.ts");
 
 describe("getModel", () => {
@@ -34,6 +40,17 @@ describe("getModel", () => {
 
   it("honors an explicit model override", () => {
     expect(getModel("haiku-id")).toBe("bedrock:haiku-id");
+  });
+
+  it("passes credentials to the provider explicitly, never via the env chain", () => {
+    getModel();
+    // Regression: Vercel shadows user-supplied AWS_* env vars at runtime, so
+    // relying on the SDK's implicit chain works locally and fails in prod.
+    expect(createAmazonBedrock).toHaveBeenCalledWith({
+      accessKeyId: "AKIA_TEST",
+      secretAccessKey: "SECRET_TEST",
+      region: "us-east-1",
+    });
   });
 });
 

--- a/packages/agent/src/config/index.ts
+++ b/packages/agent/src/config/index.ts
@@ -24,10 +24,18 @@ export interface LlmKey {
 }
 
 /** The Bedrock model (our key). `modelId` overrides the env inference profile —
- * used by the lightweight title-generation helper. */
+ * used by the lightweight title-generation helper. Credentials are passed
+ * EXPLICITLY (never via the SDK's AWS_* env chain): Vercel shadows
+ * user-supplied AWS_* variables at runtime, so relying on the chain works
+ * locally and silently fails in production. Undefined values (local dev
+ * without BEDROCK_*) fall back to the SDK's own chain. */
 export function getModel(modelId?: string): LanguageModel {
   const env = getServerEnv();
-  const bedrock = createAmazonBedrock();
+  const bedrock = createAmazonBedrock({
+    accessKeyId: env.bedrockAccessKeyId,
+    secretAccessKey: env.bedrockSecretAccessKey,
+    region: env.bedrockRegion,
+  });
   return bedrock(modelId ?? env.bedrockModel);
 }
 

--- a/packages/core/src/__tests__/env.test.ts
+++ b/packages/core/src/__tests__/env.test.ts
@@ -85,6 +85,39 @@ describe("parseServerEnv", () => {
     expect(env.braintrustProject).toBe("animus-prod");
   });
 
+  it("prefers BEDROCK_* credentials over the AWS_* fallbacks", () => {
+    const env = parseServerEnv({
+      ...MINIMAL,
+      BEDROCK_ACCESS_KEY_ID: "bedrock-akid",
+      BEDROCK_SECRET_ACCESS_KEY: "bedrock-secret",
+      BEDROCK_REGION: "eu-west-1",
+      AWS_ACCESS_KEY_ID: "aws-akid",
+      AWS_SECRET_ACCESS_KEY: "aws-secret",
+      AWS_REGION: "us-east-1",
+    });
+    expect(env.bedrockAccessKeyId).toBe("bedrock-akid");
+    expect(env.bedrockSecretAccessKey).toBe("bedrock-secret");
+    expect(env.bedrockRegion).toBe("eu-west-1");
+  });
+
+  it("falls back to AWS_* credentials when BEDROCK_* are unset (local dev)", () => {
+    const env = parseServerEnv({
+      ...MINIMAL,
+      AWS_ACCESS_KEY_ID: "aws-akid",
+      AWS_SECRET_ACCESS_KEY: "aws-secret",
+      AWS_REGION: "us-east-1",
+    });
+    expect(env.bedrockAccessKeyId).toBe("aws-akid");
+    expect(env.bedrockSecretAccessKey).toBe("aws-secret");
+    expect(env.bedrockRegion).toBe("us-east-1");
+  });
+
+  it("leaves Bedrock credentials undefined when neither is set", () => {
+    const env = parseServerEnv(MINIMAL);
+    expect(env.bedrockAccessKeyId).toBeUndefined();
+    expect(env.bedrockRegion).toBeUndefined();
+  });
+
   it("rejects an invalid NODE_ENV", () => {
     expect(() => parseServerEnv({ ...MINIMAL, NODE_ENV: "staging" })).toThrow();
   });

--- a/packages/core/src/env/server.ts
+++ b/packages/core/src/env/server.ts
@@ -38,9 +38,19 @@ const ServerEnvSchema = z.object({
   /** Optional — magic links log to the console when unset. */
   RESEND_API_KEY: z.string().optional(),
   RESEND_FROM: z.string().default("animus <onboarding@resend.dev>"),
-  /** Amazon Bedrock inference-profile id for the agent's Claude model. AWS
-   * credentials/region resolve from AWS_* env vars or the AWS credential chain. */
+  /** Amazon Bedrock inference-profile id for the agent's Claude model. */
   BEDROCK_MODEL: z.string().default("us.anthropic.claude-opus-4-6-v1"),
+  /** Bedrock credentials/region, passed to the provider EXPLICITLY. The BEDROCK_*
+   * names exist because AWS_* is a special namespace on Vercel: the platform
+   * (which itself runs on AWS) shadows user-supplied AWS_* values at runtime, so
+   * they silently never reach the process. Locally the AWS_* fallbacks keep the
+   * usual .env working. */
+  BEDROCK_ACCESS_KEY_ID: z.string().optional(),
+  BEDROCK_SECRET_ACCESS_KEY: z.string().optional(),
+  BEDROCK_REGION: z.string().optional(),
+  AWS_ACCESS_KEY_ID: z.string().optional(),
+  AWS_SECRET_ACCESS_KEY: z.string().optional(),
+  AWS_REGION: z.string().optional(),
   /** Exa API key used by the agent's web search and fetch tools. */
   EXA_API_KEY: z.string().optional(),
   /** Braintrust API key for LLM observability. When set, the agent's AI SDK
@@ -72,7 +82,12 @@ const ServerEnvSchema = z.object({
 });
 
 export interface ServerEnv {
+  /** Explicit Bedrock credentials (BEDROCK_* with AWS_* fallback for local dev);
+   * undefined lets the SDK's own credential chain apply. */
+  bedrockAccessKeyId?: string;
   bedrockModel: string;
+  bedrockRegion?: string;
+  bedrockSecretAccessKey?: string;
   betterAuthApiKey?: string;
   betterAuthSecret: string;
   betterAuthUrl: string;
@@ -144,6 +159,10 @@ export function parseServerEnv(
     resendApiKey: e.RESEND_API_KEY,
     resendFrom: e.RESEND_FROM,
     bedrockModel: e.BEDROCK_MODEL,
+    bedrockAccessKeyId: e.BEDROCK_ACCESS_KEY_ID ?? e.AWS_ACCESS_KEY_ID,
+    bedrockSecretAccessKey:
+      e.BEDROCK_SECRET_ACCESS_KEY ?? e.AWS_SECRET_ACCESS_KEY,
+    bedrockRegion: e.BEDROCK_REGION ?? e.AWS_REGION,
     braintrustApiKey: e.BRAINTRUST_API_KEY,
     braintrustProject: e.BRAINTRUST_PROJECT,
     creditsGlobalCapUsd: e.CREDITS_GLOBAL_CAP_USD,


### PR DESCRIPTION
## The bug (why chat never worked in prod)

The Bedrock provider was created bare (`createAmazonBedrock()`), relying on the SDK's implicit `AWS_*` environment chain. That chain works locally (`--env-file`) — but **Vercel owns the `AWS_*` namespace at runtime**: per [Vercel's KB](https://vercel.com/kb/guide/how-can-i-use-aws-sdk-environment-variables-on-vercel) and [reserved-vars docs](https://vercel.com/docs/environment-variables/reserved-environment-variables), the platform (which runs on AWS) shadows user-supplied `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`, and its own injected values "do not grant any AWS permissions." So the dashboard listed our credentials while the process never received them: every chat turn died mid-stream with `AWS access key ID setting is missing`, masked as HTTP 200 (status is committed before the stream errors).

## The fix (Vercel's own prescribed pattern)

Custom names + explicit pass-through:
- `@animus/core/env`: new `BEDROCK_ACCESS_KEY_ID` / `BEDROCK_SECRET_ACCESS_KEY` / `BEDROCK_REGION`, **falling back to `AWS_*`** so local dev with the existing `.env` is unchanged.
- `getModel()`: hands the credentials to `createAmazonBedrock({...})` explicitly. All-undefined still defers to the SDK chain (future IAM-role hosting keeps working).

Prod env vars are set (`BEDROCK_*` on animus-api); merging this auto-deploys and picks them up.

## Tests
- env: `BEDROCK_*` precedence over `AWS_*`, fallback when unset, undefined pass-through
- config: regression asserting the provider is constructed with explicit credentials (the exact failure mode: implicit chain ⇒ works locally, dies on Vercel)
- Full gates: typecheck ✓ lint ✓ knip ✓ vitest **340 passed**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes production chat failures by passing explicit Bedrock credentials instead of relying on the SDK’s `AWS_*` env chain, which Vercel shadows at runtime. Uses `BEDROCK_*` vars with `AWS_*` fallback for local dev and forwards them to `@ai-sdk/amazon-bedrock`.

- **Bug Fixes**
  - Added `BEDROCK_ACCESS_KEY_ID` / `BEDROCK_SECRET_ACCESS_KEY` / `BEDROCK_REGION` to `@animus/core/env`, falling back to `AWS_*`.
  - `getModel()` now passes credentials explicitly to `createAmazonBedrock({...})`; undefined values defer to the SDK chain.
  - Tests cover `BEDROCK_*` precedence, `AWS_*` fallback, undefined pass-through, and a regression ensuring explicit provider credentials.

<sup>Written for commit 195417c9cc207f858eccb13eaac6d7fe57bb3fc6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/KacemMathlouthi/animus/pull/32?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

