### PR TITLE
chore: slim the API container image (3.1GB → 473MB)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,10 @@
 node_modules
 **/node_modules
 .git
+# The API image never runs web code — but the workspace manifest must stay:
+# bun install validates the lockfile against every workspace member.
+apps/web/**
+!apps/web/package.json
 .turbo
 **/.turbo
 **/dist

--- a/Dockerfile.vercel
+++ b/Dockerfile.vercel
@@ -20,7 +20,10 @@ COPY packages/agent/package.json packages/agent/
 COPY packages/auth/package.json packages/auth/
 COPY packages/core/package.json packages/core/
 COPY packages/db/package.json packages/db/
-RUN bun install --frozen-lockfile
+# --production drops every workspace's devDependencies (vitest, drizzle-kit,
+# the web toolchain) — none are imported at runtime; the boot probe in CI of
+# record: / and /health verified after every image change.
+RUN bun install --frozen-lockfile --production
 
 COPY . .
 


### PR DESCRIPTION
Two changes, both verified by a local build + boot:

1. **`.dockerignore`**: exclude `apps/web/**` from the build context — the API image never runs web code. Its `package.json` is re-included (`!apps/web/package.json`) because `bun install --frozen-lockfile` validates the lockfile against every workspace member.
2. **`Dockerfile.vercel`**: `bun install --production` — drops all workspace devDependencies (vitest, drizzle-kit, TypeScript tooling, the web build stack), which were the bulk of the old image.

**Result: 3.12GB → 473MB (−85%).** Verified: image builds, boots with the local env, `GET /` returns the banner, `GET /health` reports `assets: up` (OG fonts/paintings ship) — only `database: down` as expected from a local container without DB reachability.

Wins: faster deploy push/pull, faster cold starts, and the Vercel registry storage quota (3.29/10 GB) stops accumulating ~3GB per retained deployment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shrink the API container image from 3.1GB to 473MB by excluding web sources and installing only production deps with `bun`. This speeds deploy pushes/pulls and cold starts, and reduces Vercel registry storage usage.

- **Refactors**
  - `.dockerignore`: exclude `apps/web/**`; keep `apps/web/package.json` for lockfile validation.
  - `Dockerfile.vercel`: use `bun install --frozen-lockfile --production` to drop workspace devDependencies (`vitest`, `drizzle-kit`, TypeScript tooling, web build stack).

<sup>Written for commit dd200347191c692ee80d764d3dd17e8174beecf5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/KacemMathlouthi/animus/pull/33?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

