### PR TITLE
fix(agent): Bedrock retry budget + ElevenLabs key redaction in tool output

### DIFF
--- a/packages/agent/src/__tests__/agent.test.ts
+++ b/packages/agent/src/__tests__/agent.test.ts
@@ -71,6 +71,14 @@ describe("createManimAgent", () => {
     expect(captured.config?.instructions.length).toBeGreaterThan(0);
   });
 
+  it("raises the retry budget so provider throttling waits instead of dying", () => {
+    build();
+
+    // Bedrock 429s on fresh-account quotas a few calls into a turn; the SDK
+    // default of 2 retries abandons the loop mid-turn.
+    expect(captured.config?.maxRetries).toBe(6);
+  });
+
   it("runs on the user's BYOK model when an LLM key is provided", () => {
     build(undefined, {
       provider: "anthropic",

--- a/packages/agent/src/__tests__/manim-tools.test.ts
+++ b/packages/agent/src/__tests__/manim-tools.test.ts
@@ -208,6 +208,46 @@ describe("runCommand log truncation", () => {
   });
 });
 
+describe("secret redaction at the tool boundary", () => {
+  // Regression: the agent ran `env | grep -i eleven` in prod and the tool
+  // reflected the full ElevenLabs key into the chat and the persisted
+  // message snapshot. The sandbox holds the key in its env, so any echo of
+  // it must be scrubbed before the model sees the output.
+  it("scrubs the ElevenLabs key from runCommand output", async () => {
+    const execute = runTool(
+      "ELEVENLABS_API_KEY=el-test-key\nELEVEN_API_KEY=el-test-key\n"
+    );
+
+    const output = await execute({ command: "env | grep -i eleven" }, EXEC_CTX);
+
+    expect(output.output).not.toContain("el-test-key");
+    expect(output.output).toContain("[redacted:elevenlabs-key]");
+  });
+
+  it("scrubs the ElevenLabs key from readFile content", async () => {
+    const state = createFakeSandbox({
+      [`${"/home/daytona/project"}/.env`]: "ELEVENLABS_API_KEY=el-test-key\n",
+    });
+    const tools = createManimTools({
+      sandbox: state.sandbox,
+      conversationId: "conv-1",
+      saveVideo: vi.fn(() => Promise.resolve("https://example.com/v.mp4")),
+      backgroundMusicUrl: vi.fn(() => Promise.resolve("https://music.test")),
+      elevenLabsApiKey: "el-test-key",
+      meter: { ttsChars: 0 },
+    });
+    const read = tools.readFile;
+    if (!read?.execute) {
+      throw new Error("readFile tool is not executable");
+    }
+
+    const output = await read.execute({ path: ".env" }, EXEC_CTX);
+
+    expect(output.content).not.toContain("el-test-key");
+    expect(output.content).toContain("[redacted:elevenlabs-key]");
+  });
+});
+
 const MASTER = "/home/daytona/project/media/videos/scene/1080p60/Main.mp4";
 const MUSIC_MASTER =
   "/home/daytona/project/media/videos/scene/1080p60/Main.music.mp4";

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -30,6 +30,10 @@ export function createManimAgent(deps: {
 }): ToolLoopAgent<never, ToolSet, never> {
   return new ToolLoopAgent({
     model: resolveModel(deps.llmKey).model,
+    // Bedrock throttles fresh accounts hard (429 "Too many requests" a few
+    // calls into a turn). The default 2 retries gives up mid-loop and the turn
+    // stalls; 6 retries of exponential backoff rides out the rate window.
+    maxRetries: 6,
     instructions: MANIM_SYSTEM_PROMPT,
     tools: createTools({
       manim: {

--- a/packages/agent/src/tools/manim.ts
+++ b/packages/agent/src/tools/manim.ts
@@ -151,6 +151,15 @@ export function createManimTools(deps: {
     meter,
   } = deps;
 
+  /** Scrub the ElevenLabs key from anything the sandbox echoes back. The key
+   * lives in the sandbox env, so `env`, `cat .env`, or an error trace can
+   * reflect it into tool output — which the model then streams into the chat
+   * and the persisted message snapshot. Redact at the tool boundary. */
+  const redactSecrets = (text: string): string =>
+    elevenLabsApiKey
+      ? text.split(elevenLabsApiKey).join("[redacted:elevenlabs-key]")
+      : text;
+
   return {
     writeFile: tool({
       description:
@@ -206,7 +215,7 @@ export function createManimTools(deps: {
       inputSchema: ReadFileInputSchema,
       execute: async ({ path }): Promise<ReadFileOutput> => {
         const buffer = await sandbox.fs.downloadFile(resolvePath(path));
-        return { path, content: buffer.toString("utf8") };
+        return { path, content: redactSecrets(buffer.toString("utf8")) };
       },
     }),
     listFiles: tool({
@@ -231,7 +240,7 @@ export function createManimTools(deps: {
         return {
           command,
           exitCode: res.exitCode,
-          output: tailLog(commandOutput(res)),
+          output: redactSecrets(tailLog(commandOutput(res))),
         };
       },
     }),
@@ -258,7 +267,7 @@ export function createManimTools(deps: {
           RENDER_TIMEOUT_SEC
         );
         const output = commandOutput(res);
-        const logs = tailLog(output);
+        const logs = redactSecrets(tailLog(output));
 
         if (res.exitCode !== 0) {
           return { ok: false, file, scene, exitCode: res.exitCode, logs };


### PR DESCRIPTION
Two production findings from the first real video-generation attempt, one commit each:

## 1. Bedrock throttling stalled the turn (`maxRetries: 6`)

Braintrust captured `AI_APICallError: Too many requests` — fresh-account Bedrock quotas 429 a few calls into an agent turn, and the SDK's default 2 retries abandons the loop mid-turn (the user had to type "continue"). Six retries of exponential backoff rides out the rate window. The lasting fix is an AWS Service Quotas increase for the Opus on-demand limits; this makes turns survive until then.

## 2. The sandbox leaked the ElevenLabs API key into the chat

The agent debugged a TTS failure with `env | grep -i eleven` — and the tool returned the **full key** into the streamed chat and the persisted message snapshot. The sandbox necessarily holds the key in its env (manim-voiceover reads it), so any echo can reflect it.

Fix: scrub every occurrence of the key at the tool boundary — `runCommand` output, `readFile` content, and `renderScene` logs — replacing it with `[redacted:elevenlabs-key]` before the model ever sees it. Regression tests reproduce the exact `env | grep` leak and a `cat .env` variant.

⚠️ **The exposed key is burned regardless** (it's in chat history/DB): rotate it in the ElevenLabs dashboard and update `ELEVENLABS_API_KEY` on the Vercel project.

## Gates
typecheck ✓ lint ✓ knip ✓ agent suite + full vitest green (2 new redaction tests, 1 retry test)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raise the Bedrock retry budget to 6 so turns survive throttling, and redact the ElevenLabs API key from sandbox tool output to prevent secret leaks into chat history.

- **Bug Fixes**
  - Set `maxRetries` to 6 to handle Bedrock 429s without stalling the tool loop.
  - Scrub the ElevenLabs key at the tool boundary (runCommand output, readFile content, render logs), replacing matches with `[redacted:elevenlabs-key]`.

- **Migration**
  - Rotate the ElevenLabs API key and update `ELEVENLABS_API_KEY` in the Vercel project.

<sup>Written for commit 17343a60711aa8758607f1c337297289df33fa43. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/KacemMathlouthi/animus/pull/34?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

