### PR TITLE
fix(deploy): keep-warm health ping (kills the cold-start seconds)

### DIFF
--- a/.github/workflows/keep-warm.yml
+++ b/.github/workflows/keep-warm.yml
@@ -1,0 +1,18 @@
+# Keeps the deployed API responsive: the Vercel container scales to zero after
+# ~5 idle minutes and Neon autosuspends on the same clock, so the first request
+# after idle pays several seconds of stacked cold starts. /health runs a DB
+# round-trip, so one ping keeps the container AND the database warm.
+# (Vercel Cron would be the native tool, but sub-daily crons need the Pro plan.)
+name: keep-warm
+on:
+  schedule:
+    - cron: "*/5 * * * *"
+  workflow_dispatch:
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Ping API health (wakes container + database)
+        run: |
+          curl -sf -m 45 --retry 2 --retry-delay 5 https://animus-api.vercel.app/health


### PR DESCRIPTION
## The complaint
The deployed API intermittently takes **many seconds** for basic requests, versus instant locally.

## Measured diagnosis
- Warm requests: 210–340ms (edge `cdg1` → container `iad1` transatlantic hop — unavoidable while the stack lives in US East next to Neon).
- The multi-second cases: **two stacked cold starts** — the container scales to zero after ~5 idle minutes, and **Neon's free tier autosuspends on the same clock**. Live measurement during diagnosis: ~6s to first byte, container `uptime: 4.4s` on arrival.

## Fix
A GitHub Actions schedule pings `/health` every 5 minutes. Because `/health` does a real `select 1`, one ping keeps **both** the container and the database awake. `workflow_dispatch` allows manual runs.

Why not Vercel Cron: sub-daily crons require the Pro plan (deploy-time error confirmed the account is Hobby — which also means the function duration cap is 300s, docs corrected separately).

## Cost
- Vercel: container sits near its always-on memory ceiling ≈ $15/mo — already inside the budget envelope.
- Neon: ~190 free compute-hours/mo at 0.25CU ≈ covers always-on.
- GitHub Actions: free.

## Remaining latency after this merges
The ~250ms-per-call floor from Tunisia/Europe → `iad1` remains (each studio load fires several calls). If the audience skews EU, the eventual fix is relocating the pair (Neon EU region + container region) together — parked as a future decision since they must move as a unit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the API responsive by preventing cold starts. A GitHub Actions cron pings `/health` every 5 minutes to keep the Vercel container and Neon database warm.

- **Bug Fixes**
  - Scheduled workflow runs every 5 minutes and supports manual `workflow_dispatch`.
  - Uses a simple `curl` health check with timeout and retries.
  - Chose Actions instead of Vercel Cron due to Hobby plan limits on sub-daily schedules.

<sup>Written for commit f4426095c30a8e38a8c1a93cc332920cb9ad44e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/KacemMathlouthi/animus/pull/36?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

