### PR TITLE
fix(web): landing & settings UX polish pass

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -7,6 +7,7 @@ import {
 	Route,
 	Routes,
 	useLocation,
+	useNavigationType,
 } from "react-router";
 import { RequireAuth } from "@/features/auth/components/require-auth";
 import { AccountSection } from "@/features/settings/components/account-section";
@@ -24,7 +25,12 @@ import { VerifyLoginPage } from "@/pages/verify-login-page";
 
 function ScrollToTop() {
 	const location = useLocation();
+	const navigationType = useNavigationType();
 	useEffect(() => {
+		// Back/forward: let the browser restore the previous scroll position.
+		if (navigationType === "POP") {
+			return;
+		}
 		const target = location.hash
 			? document.getElementById(location.hash.slice(1))
 			: null;
@@ -33,7 +39,7 @@ function ScrollToTop() {
 			return;
 		}
 		window.scrollTo({ top: 0, behavior: "instant" });
-	}, [location]);
+	}, [location, navigationType]);
 	return null;
 }
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,5 +1,13 @@
 import { Analytics } from "@vercel/analytics/react";
-import { BrowserRouter, Navigate, Outlet, Route, Routes } from "react-router";
+import { useEffect } from "react";
+import {
+	BrowserRouter,
+	Navigate,
+	Outlet,
+	Route,
+	Routes,
+	useLocation,
+} from "react-router";
 import { RequireAuth } from "@/features/auth/components/require-auth";
 import { AccountSection } from "@/features/settings/components/account-section";
 import { GenerationSection } from "@/features/settings/components/generation-section";
@@ -14,9 +22,25 @@ import { StudioPage } from "@/pages/studio-page";
 import { TermsPage } from "@/pages/terms-page";
 import { VerifyLoginPage } from "@/pages/verify-login-page";
 
+function ScrollToTop() {
+	const location = useLocation();
+	useEffect(() => {
+		const target = location.hash
+			? document.getElementById(location.hash.slice(1))
+			: null;
+		if (target) {
+			target.scrollIntoView();
+			return;
+		}
+		window.scrollTo({ top: 0, behavior: "instant" });
+	}, [location]);
+	return null;
+}
+
 function App() {
 	return (
 		<BrowserRouter>
+			<ScrollToTop />
 			<Routes>
 				<Route element={<LandingPage />} path="/" />
 				<Route element={<AuthPage />} path="/auth" />

--- a/apps/web/src/components/ui/cta-button.tsx
+++ b/apps/web/src/components/ui/cta-button.tsx
@@ -1,9 +1,11 @@
 import { Link } from "react-router";
 import { cn } from "@/lib/utils";
 
-/* Adapted from pixel-perfect's book-demo button: the sliding pill picks up the
-   brand primary token (warm loam in light, warm sand in dark) instead of the
-   registry's fixed variants, and the dot-wave keyframes live in index.css. */
+/* The primary call-to-action button: a sliding accent pill of dotted chevrons
+   over a theme-aware root. The pill picks up the brand primary token (warm
+   loam in light, warm sand in dark) and the root flips with the theme (light
+   card in light mode, dark gradient in dark). The dot-wave keyframes live in
+   index.css. */
 
 const chevronDots = [
 	{ id: "d1", cx: 2, cy: 2, delay: 0 },
@@ -36,7 +38,7 @@ function DoubleChevron({ index }: { index: number }) {
 			<g fill="var(--primary-foreground)">
 				{chevronDots.map((dot) => (
 					<circle
-						className="bd-dot"
+						className="cta-dot"
 						cx={dot.cx}
 						cy={dot.cy}
 						key={dot.id}
@@ -50,9 +52,9 @@ function DoubleChevron({ index }: { index: number }) {
 }
 
 const rootClasses = cn(
-	"group/btn bd-root relative inline-flex h-11 w-36 overflow-hidden rounded-[12px]",
-	"bg-gradient-to-b from-[#1f1f1f] to-[#0a0a0a] dark:from-[#2c2c2c] dark:to-[#161616]",
-	"shadow-[inset_0_1px_0_rgba(255,255,255,0.08),0_4px_12px_rgba(0,0,0,0.18)]",
+	"group/btn cta-root relative inline-flex h-11 w-36 overflow-hidden rounded-[12px]",
+	"border border-black/10 bg-gradient-to-b from-[#fbfaf5] to-[#eae4d8] dark:border-transparent dark:from-[#2c2c2c] dark:to-[#161616]",
+	"shadow-[inset_0_1px_0_rgba(255,255,255,0.9),0_4px_12px_rgba(0,0,0,0.10)] dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.08),0_4px_12px_rgba(0,0,0,0.18)]",
 	"transition-transform active:scale-[0.97]",
 	"focus-visible:outline-2 focus-visible:outline-offset-2",
 );
@@ -66,7 +68,7 @@ function ButtonBody({
 		<>
 			<span
 				className={cn(
-					"absolute inset-y-0 right-4 flex items-center font-medium text-[14px] text-white tracking-tight",
+					"absolute inset-y-0 right-4 flex items-center font-medium text-[14px] text-foreground tracking-tight",
 					"transition-[transform,opacity] duration-200 ease-snappy motion-reduce:transition-none",
 					"group-hover/btn:translate-x-2 group-hover/btn:opacity-0",
 					"group-focus-visible/btn:translate-x-2 group-focus-visible/btn:opacity-0",
@@ -98,7 +100,7 @@ function ButtonBody({
 
 /** With `to`, renders a real router link (middle-click, link role, crawlable);
  * without it, a plain button for onClick use. */
-export function BookDemoButton({
+export function CtaButton({
 	className,
 	children,
 	to,

--- a/apps/web/src/components/ui/cta-button.tsx
+++ b/apps/web/src/components/ui/cta-button.tsx
@@ -3,9 +3,9 @@ import { cn } from "@/lib/utils";
 
 /* The primary call-to-action button: a sliding accent pill of dotted chevrons
    over a theme-aware root. The pill picks up the brand primary token (warm
-   loam in light, warm sand in dark) and the root flips with the theme (light
-   card in light mode, dark gradient in dark). The dot-wave keyframes live in
-   index.css. */
+   loam in light, warm sand in dark) and the root flips with the theme via the
+   shared .cta-surface class (also used by the hero prompt shell). The surface
+   and dot-wave keyframes live in index.css. */
 
 const chevronDots = [
 	{ id: "d1", cx: 2, cy: 2, delay: 0 },
@@ -52,9 +52,7 @@ function DoubleChevron({ index }: { index: number }) {
 }
 
 const rootClasses = cn(
-	"group/btn cta-root relative inline-flex h-11 w-36 overflow-hidden rounded-[12px]",
-	"border border-black/10 bg-gradient-to-b from-[#fbfaf5] to-[#eae4d8] dark:border-transparent dark:from-[#2c2c2c] dark:to-[#161616]",
-	"shadow-[inset_0_1px_0_rgba(255,255,255,0.9),0_4px_12px_rgba(0,0,0,0.10)] dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.08),0_4px_12px_rgba(0,0,0,0.18)]",
+	"group/btn cta-root cta-surface relative inline-flex h-11 w-36 overflow-hidden rounded-[12px]",
 	"transition-transform active:scale-[0.97]",
 	"focus-visible:outline-2 focus-visible:outline-offset-2",
 );

--- a/apps/web/src/features/landing/components/auth-actions.tsx
+++ b/apps/web/src/features/landing/components/auth-actions.tsx
@@ -8,11 +8,23 @@ import { Button } from "@/components/ui/button";
 import { useSession } from "@/lib/auth-client";
 import { cn } from "@/lib/utils";
 
+/** True once any instance has seen the session resolve. `useSession` flips
+ * back to pending on every background refetch (window focus, another
+ * subscriber mounting, route changes remounting the header) — hiding the
+ * buttons each time reads as flickering when the round-trip is slow, so only
+ * the very first load gets the blank slot. */
+let sessionResolvedOnce = false;
+
 export function AuthActions({ stacked = false }: { stacked?: boolean }) {
 	const { data, isPending } = useSession();
 
-	// Avoid flashing the signed-out buttons before the session resolves.
-	if (isPending) {
+	if (!isPending) {
+		sessionResolvedOnce = true;
+	}
+
+	// Avoid flashing the signed-out buttons before the session first resolves;
+	// afterwards, refetches keep rendering the last-known state.
+	if (isPending && !sessionResolvedOnce) {
 		return null;
 	}
 

--- a/apps/web/src/features/landing/components/cta.tsx
+++ b/apps/web/src/features/landing/components/cta.tsx
@@ -1,6 +1,6 @@
 import { LogoMark } from "@/components/brand/logo-mark";
 import { DecorIcon } from "@/components/decor-icon";
-import { BookDemoButton } from "@/components/pixel-perfect/book-demo-button";
+import { CtaButton } from "@/components/ui/cta-button";
 import { useCtaTarget } from "@/features/landing/hooks/use-cta-target";
 
 export function CallToAction() {
@@ -28,9 +28,9 @@ export function CallToAction() {
 			</p>
 
 			<div className="flex items-center justify-center gap-2 pt-1">
-				<BookDemoButton className="h-12 w-[13rem]" to={ctaTarget}>
+				<CtaButton className="h-12 w-[13rem]" to={ctaTarget}>
 					Ask your first question
-				</BookDemoButton>
+				</CtaButton>
 			</div>
 		</div>
 	);

--- a/apps/web/src/features/landing/components/header.tsx
+++ b/apps/web/src/features/landing/components/header.tsx
@@ -39,7 +39,7 @@ export function Header() {
 					<div>
 						{navLinks.map((link) => (
 							<Button asChild key={link.label} size="sm" variant="ghost">
-								<a href={link.href}>{link.label}</a>
+								<Link to={link.href}>{link.label}</Link>
 							</Button>
 						))}
 					</div>

--- a/apps/web/src/features/landing/components/hero-prompt.tsx
+++ b/apps/web/src/features/landing/components/hero-prompt.tsx
@@ -92,7 +92,7 @@ export function HeroPrompt({ className }: { className?: string }) {
 				<form
 					className={cn(
 						"prompt-well flex flex-col gap-2.5 rounded-xl border p-3",
-						"transition-[border-color] duration-200 ease-snappy focus-within:border-ring/50",
+						"transition-[border-color] duration-200 ease-snappy focus-within:border-primary/45",
 					)}
 					onSubmit={(event) => {
 						event.preventDefault();

--- a/apps/web/src/features/landing/components/hero-prompt.tsx
+++ b/apps/web/src/features/landing/components/hero-prompt.tsx
@@ -84,7 +84,7 @@ export function HeroPrompt({ className }: { className?: string }) {
 
 	return (
 		<div className={cn("w-full max-w-2xl", className)}>
-			<div className="prompt-shell flex flex-col gap-2 rounded-2xl p-2.5">
+			<div className="cta-surface flex flex-col gap-2 rounded-2xl p-2.5">
 				<div className="flex items-center px-1.5 pt-0.5 font-medium text-muted-foreground text-xs">
 					<span>$5.00 in free credits</span>
 				</div>

--- a/apps/web/src/features/landing/components/launch-video.tsx
+++ b/apps/web/src/features/landing/components/launch-video.tsx
@@ -1,9 +1,21 @@
+import { useState } from "react";
 import { DecorIcon } from "@/components/decor-icon";
 import { FullWidthDivider } from "@/features/landing/components/full-width-divider";
+import { cn } from "@/lib/utils";
+
+const posterClasses = cn(
+	"pointer-events-none absolute inset-0 h-full w-full object-cover",
+	"transition-opacity duration-700 ease-fluid",
+);
 
 /** The "See animus in action" section. Expects the launch video at
- * `public/launch.mp4`; the hero's "Watch the video" button scrolls here via `#video`. */
+ * `public/launch.mp4`; the hero's "Watch the video" button scrolls here via `#video`.
+ * Until playback starts, a theme-aware poster overlay (the hero art, cross-fading
+ * with the light/dark toggle like the hero itself) covers the player — the native
+ * `poster` attribute can't follow a class-driven theme. */
 export function LaunchVideo() {
+	const [playing, setPlaying] = useState(false);
+
 	return (
 		<section
 			className="relative flex min-h-svh scroll-mt-20 flex-col items-center justify-center gap-10 px-4 py-20"
@@ -43,13 +55,27 @@ export function LaunchVideo() {
 						aria-label="animus launch video"
 						className="h-full w-full object-cover"
 						controls
+						onPlay={() => setPlaying(true)}
 						playsInline
-						poster="/hero/hero-dark.webp"
 						preload="metadata"
 					>
 						<source src="/launch.mp4" type="video/mp4" />
 						<track kind="captions" />
 					</video>
+					{playing ? null : (
+						<>
+							<img
+								alt=""
+								className={cn(posterClasses, "opacity-100 dark:opacity-0")}
+								src="/hero/hero-light.webp"
+							/>
+							<img
+								alt=""
+								className={cn(posterClasses, "opacity-0 dark:opacity-100")}
+								src="/hero/hero-dark.webp"
+							/>
+						</>
+					)}
 				</div>
 			</div>
 

--- a/apps/web/src/features/landing/components/launch-video.tsx
+++ b/apps/web/src/features/landing/components/launch-video.tsx
@@ -26,8 +26,6 @@ export function LaunchVideo() {
 			<DecorIcon className="size-4" position="bottom-left" />
 			<DecorIcon className="size-4" position="bottom-right" />
 
-			<FullWidthDivider className="-top-px" />
-
 			<div className="max-w-2xl space-y-3 text-center">
 				<p className="font-mono text-muted-foreground text-xs uppercase tracking-wider">
 					Watch

--- a/apps/web/src/features/landing/components/mobile-nav.tsx
+++ b/apps/web/src/features/landing/components/mobile-nav.tsx
@@ -1,5 +1,6 @@
 import { MenuIcon, XIcon } from "lucide-react";
 import React from "react";
+import { Link } from "react-router";
 import { Button } from "@/components/ui/button";
 import { AuthActions } from "@/features/landing/components/auth-actions";
 import { navLinks } from "@/features/landing/components/nav-links";
@@ -65,9 +66,9 @@ export function MobileNav() {
 									key={link.label}
 									variant="ghost"
 								>
-									<a href={link.href} onClick={close}>
+									<Link onClick={close} to={link.href}>
 										{link.label}
-									</a>
+									</Link>
 								</Button>
 							))}
 						</div>

--- a/apps/web/src/features/settings/components/generation-section.tsx
+++ b/apps/web/src/features/settings/components/generation-section.tsx
@@ -114,30 +114,6 @@ export function GenerationSection() {
 				</SettingRow>
 
 				<SettingRow
-					description="Use your own brand colors across the animation."
-					disabled
-					title={
-						<span className="flex items-center gap-2">
-							Brand palette
-							<Badge variant="outline">
-								<LockIcon className="size-3" />
-								Coming soon
-							</Badge>
-						</span>
-					}
-				>
-					<div className="flex gap-1.5">
-						{["#4a3212", "#b08442", "#e8d9c0", "#1c1917"].map((color) => (
-							<span
-								className="size-6 rounded-full border"
-								key={color}
-								style={{ backgroundColor: color }}
-							/>
-						))}
-					</div>
-				</SettingRow>
-
-				<SettingRow
 					description="Add a subtle soundtrack under the narration."
 					title="Background music"
 				>
@@ -166,16 +142,56 @@ export function GenerationSection() {
 				) : null}
 
 				<SettingRow
-					description="Typeface used for on-screen text and titles."
-					title="Font"
+					description="The narrator for your videos. Hover a voice and press play to hear a sample."
+					stacked
+					title="Voiceover"
 				>
-					<Select
-						onValueChange={(value) =>
-							update({ font: value as GenerationSettings["font"] })
-						}
-						value={config.font}
-					>
-						<SelectTrigger aria-label="Font" className="w-44">
+					<VoicePicker
+						onValueChange={(id) => update({ voiceId: id })}
+						value={config.voiceId}
+						voices={VOICES}
+					/>
+				</SettingRow>
+
+				<SettingRow
+					description="Use your own brand colors across the animation."
+					disabled
+					title={
+						<span className="flex items-center gap-2">
+							Brand palette
+							<Badge variant="outline">
+								<LockIcon className="size-3" />
+								Coming soon
+							</Badge>
+						</span>
+					}
+				>
+					<div className="flex gap-1.5">
+						{["#4a3212", "#b08442", "#e8d9c0", "#1c1917"].map((color) => (
+							<span
+								className="size-6 rounded-full border"
+								key={color}
+								style={{ backgroundColor: color }}
+							/>
+						))}
+					</div>
+				</SettingRow>
+
+				<SettingRow
+					description="Typeface used for on-screen text and titles."
+					disabled
+					title={
+						<span className="flex items-center gap-2">
+							Font
+							<Badge variant="outline">
+								<LockIcon className="size-3" />
+								Coming soon
+							</Badge>
+						</span>
+					}
+				>
+					<Select value={config.font}>
+						<SelectTrigger aria-label="Font" className="w-44" disabled>
 							<SelectValue />
 						</SelectTrigger>
 						<SelectContent>
@@ -186,18 +202,6 @@ export function GenerationSection() {
 							))}
 						</SelectContent>
 					</Select>
-				</SettingRow>
-
-				<SettingRow
-					description="The narrator for your videos. Hover a voice and press play to hear a sample."
-					stacked
-					title="Voiceover"
-				>
-					<VoicePicker
-						onValueChange={(id) => update({ voiceId: id })}
-						value={config.voiceId}
-						voices={VOICES}
-					/>
 				</SettingRow>
 			</div>
 

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -315,20 +315,18 @@
 	color: transparent;
 }
 
-/* Hero prompt — flat treatment matching the CTA button (components/ui/
-   cta-button.tsx): a theme-aware gradient plate with a thin border, one soft
-   drop shadow, and a subtle top highlight. No gradient-border or bevel
-   tricks. */
-
-/* Outer plate — same surface language as the CTA button root. */
-.prompt-shell {
+/* Shared flat plate surface — the single source of the CTA visual language,
+   used by both the CTA button root (components/ui/cta-button.tsx) and the
+   hero prompt shell: a theme-aware gradient plate with a thin border, one
+   soft drop shadow, and a subtle top highlight. */
+.cta-surface {
 	border: 1px solid rgba(0, 0, 0, 0.1);
 	background: linear-gradient(180deg, #fbfaf5 0%, #eae4d8 100%);
 	box-shadow:
 		inset 0 1px 0 rgba(255, 255, 255, 0.9),
 		0 4px 12px rgba(0, 0, 0, 0.1);
 }
-.dark .prompt-shell {
+.dark .cta-surface {
 	border-color: transparent;
 	background: linear-gradient(180deg, #2c2c2c 0%, #161616 100%);
 	box-shadow:

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -400,10 +400,10 @@
 		0 1px 1.5px rgba(0, 0, 0, 0.12);
 }
 
-/* CTA book-demo button (components/pixel-perfect/book-demo-button.tsx) — the
-   dotted chevrons shimmer slowly at rest and march faster on hover/focus.
-   Static dots when reduced motion is preferred. */
-@keyframes bd-dot-wave {
+/* CTA button (components/ui/cta-button.tsx) — the dotted chevrons shimmer
+   slowly at rest and march faster on hover/focus. Static dots when reduced
+   motion is preferred. */
+@keyframes cta-dot-wave {
 	0%,
 	65%,
 	100% {
@@ -415,16 +415,16 @@
 		transform: translateX(0.5px) scale(1.08);
 	}
 }
-.bd-dot {
+.cta-dot {
 	transform-box: fill-box;
 	transform-origin: center;
 }
 @media (prefers-reduced-motion: no-preference) {
-	.bd-dot {
-		animation: bd-dot-wave 1.8s cubic-bezier(0.45, 0.05, 0.55, 0.95) infinite;
+	.cta-dot {
+		animation: cta-dot-wave 1.8s cubic-bezier(0.45, 0.05, 0.55, 0.95) infinite;
 	}
-	.bd-root:hover .bd-dot,
-	.bd-root:focus-visible .bd-dot {
+	.cta-root:hover .cta-dot,
+	.cta-root:focus-visible .cta-dot {
 		animation-duration: 0.95s;
 	}
 }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -315,89 +315,58 @@
 	color: transparent;
 }
 
-/* Hero prompt — skeuomorphic treatment (technique from pixel-perfect's
-   silver button): gradient borders painted with the padding-box/border-box
-   double-background trick so the rim reads as lit from above, plus layered
-   contact + drop shadows. All colors derive from theme tokens via color-mix,
-   so light and dark both get a correct bevel. */
+/* Hero prompt — flat treatment matching the CTA button (components/ui/
+   cta-button.tsx): a theme-aware gradient plate with a thin border, one soft
+   drop shadow, and a subtle top highlight. No gradient-border or bevel
+   tricks. */
 
-/* Raised outer plate. */
+/* Outer plate — same surface language as the CTA button root. */
 .prompt-shell {
-	border: 1.5px solid transparent;
-	background:
-		linear-gradient(
-			180deg,
-			color-mix(in srgb, var(--card) 90%, white) 0%,
-			var(--card) 100%
-		)
-		padding-box,
-		linear-gradient(
-			180deg,
-			color-mix(in srgb, var(--border) 50%, white) 0%,
-			var(--border) 50%,
-			color-mix(in srgb, var(--border) 75%, black) 100%
-		)
-		border-box;
+	border: 1px solid rgba(0, 0, 0, 0.1);
+	background: linear-gradient(180deg, #fbfaf5 0%, #eae4d8 100%);
 	box-shadow:
-		0 1px 2px rgba(0, 0, 0, 0.14),
-		0 10px 24px -8px rgba(0, 0, 0, 0.22);
+		inset 0 1px 0 rgba(255, 255, 255, 0.9),
+		0 4px 12px rgba(0, 0, 0, 0.1);
+}
+.dark .prompt-shell {
+	border-color: transparent;
+	background: linear-gradient(180deg, #2c2c2c 0%, #161616 100%);
+	box-shadow:
+		inset 0 1px 0 rgba(255, 255, 255, 0.08),
+		0 4px 12px rgba(0, 0, 0, 0.18);
 }
 
-/* Recessed input well — slightly darker at the top with an inner shadow, like
-   a plate milled into the shell. */
+/* Flat input well; focus warms the border and casts a soft primary halo. */
 .prompt-well {
+	background: var(--background);
+	transition:
+		border-color 0.2s,
+		box-shadow 0.2s;
+}
+.prompt-well:focus-within {
+	box-shadow: 0 0 0 3px color-mix(in srgb, var(--primary) 12%, transparent);
+}
+
+/* Primary send button — the CTA pill's gradient and highlight. */
+.prompt-send {
 	background: linear-gradient(
 		180deg,
-		color-mix(in srgb, var(--background) 97%, black) 0%,
-		var(--background) 45%
+		color-mix(in srgb, var(--primary) 85%, white) 0%,
+		var(--primary) 100%
 	);
 	box-shadow:
-		inset 0 1.5px 3px rgba(0, 0, 0, 0.1),
-		inset 0 -1px 0 color-mix(in srgb, white 7%, transparent);
+		inset 0 1px 0 rgba(255, 255, 255, 0.4),
+		0 2px 4px rgba(0, 0, 0, 0.08);
+	transition: filter 0.2s;
+}
+.prompt-send:not(:disabled):hover {
+	filter: brightness(1.07);
 }
 
-/* Polished primary send button — lighter crown, darker base, beveled rim. */
-.prompt-send {
-	border: 1.5px solid transparent;
-	background:
-		linear-gradient(
-			180deg,
-			color-mix(in srgb, var(--primary) 78%, white) 0%,
-			var(--primary) 55%,
-			color-mix(in srgb, var(--primary) 86%, black) 100%
-		)
-		padding-box,
-		linear-gradient(
-			180deg,
-			color-mix(in srgb, var(--primary) 55%, white) 0%,
-			color-mix(in srgb, var(--primary) 70%, black) 100%
-		)
-		border-box;
-	box-shadow:
-		inset 0 1px 0 rgba(255, 255, 255, 0.35),
-		0 1px 2px rgba(0, 0, 0, 0.25),
-		0 4px 10px -3px rgba(0, 0, 0, 0.2);
-}
-
-/* Soft-raised chip for secondary actions. */
+/* Quiet chip for secondary actions. */
 .prompt-chip {
-	border: 1px solid transparent;
-	background:
-		linear-gradient(
-			180deg,
-			color-mix(in srgb, var(--muted) 88%, white) 0%,
-			var(--muted) 100%
-		)
-		padding-box,
-		linear-gradient(
-			180deg,
-			color-mix(in srgb, var(--border) 55%, white) 0%,
-			var(--border) 100%
-		)
-		border-box;
-	box-shadow:
-		inset 0 1px 0 rgba(255, 255, 255, 0.2),
-		0 1px 1.5px rgba(0, 0, 0, 0.12);
+	border: 1px solid var(--border);
+	background: var(--muted);
 }
 
 /* CTA button (components/ui/cta-button.tsx) — the dotted chevrons shimmer


### PR DESCRIPTION
Seven user-reported UX fixes on the landing page and settings, verified against local dev:

- **Scroll on route change** — footer links (/privacy, /terms) opened at the old scroll position; header hash links (/#features) from the legal pages couldn't reach their section at all (plain anchors + SPA). ScrollToTop now handles both, keyed on location so re-clicks re-scroll, and the nav links go through the router.
- **CTA button** — theme-aware root (light plate in light mode, dark gradient in dark) while the pill keeps tracking the brand primary; renamed out of the pixel-perfect port to components/ui/cta-button.tsx as CtaButton (bd-* CSS hooks → cta-*).
- **Hero prompt de-skeuomorphed** — the gradient-border/bevel treatment replaced with the CTA button's flat surface language: gradient shell, flat well with a primary focus halo, pill-gradient send button with hover, quiet chip. Divider line between hero and video section removed.
- **Launch-video poster** — the hardcoded dark poster now cross-fades light/dark hero art with the theme toggle (native poster can't follow a class-driven theme); overlay drops once playback starts.
- **Settings** — Font is "Coming soon" (locked like Brand palette; the picker fonts aren't in the render sandbox yet) and both rows moved to the bottom.
- **Header auth buttons flicker (prod)** — useSession re-enters pending on every background refetch and the buttons unmounted each time; only the first-ever resolution now blanks the slot.

All gates pass: typecheck, ultracite, knip, vitest (341).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polishes the landing and settings pages with smoother navigation, a theme-aware CTA/hero, and stable auth buttons. Also updates the launch video poster and clarifies unavailable settings.

- **Bug Fixes**
  - Scroll to top or hash target on route changes; keyed on location for re-scrolls.
  - Header nav links use router `Link` to avoid full reloads and enable section scrolling.
  - Launch video uses a theme-aware poster overlay that cross-fades and disappears on play.
  - Stop header auth button flicker by only hiding the slot before the first session resolution.

- **UI Polish**
  - Reworked CTA: moved to `components/ui/cta-button.tsx` as `CtaButton`, theme-aware root, label uses `foreground`, and CSS hooks renamed `bd-*` → `cta-*`.
  - Hero prompt matched the CTA’s flat surface language with a primary focus halo and simplified chip/button styles.
  - Settings: Font marked “Coming soon” (disabled) and moved with Brand palette to the bottom.

<sup>Written for commit 79101a01e0091ab487ca069ffdbfe803dd5399f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/KacemMathlouthi/animus/pull/37?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

