### PR TITLE
feat: usage ledger tab + BYOK settings restructure

### DIFF
--- a/apps/api/src/__tests__/credits.route.test.ts
+++ b/apps/api/src/__tests__/credits.route.test.ts
@@ -2,11 +2,12 @@ import { FREE_GRANT_MICROS } from "@animus/core";
 import { Hono } from "hono";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { getOrCreateCredits } = vi.hoisted(() => ({
+const { getOrCreateCredits, listUsage } = vi.hoisted(() => ({
   getOrCreateCredits: vi.fn(),
+  listUsage: vi.fn(),
 }));
 
-vi.mock("../services/credits.ts", () => ({ getOrCreateCredits }));
+vi.mock("../services/credits.ts", () => ({ getOrCreateCredits, listUsage }));
 vi.mock("../middleware/auth.ts", () => ({
   requireAuth: (_c: unknown, next: () => Promise<void>) => next(),
 }));
@@ -27,6 +28,7 @@ function appWith(user: TestUser) {
 
 beforeEach(() => {
   getOrCreateCredits.mockReset();
+  listUsage.mockReset();
 });
 
 describe("GET /credits", () => {
@@ -44,5 +46,72 @@ describe("GET /credits", () => {
       grantMicros: FREE_GRANT_MICROS,
     });
     expect(getOrCreateCredits).toHaveBeenCalledWith("u1");
+  });
+});
+
+describe("GET /credits/usage", () => {
+  const emptyPage = { items: [], total: 0, limit: 20, offset: 0 };
+
+  it("returns the caller's usage page with defaults", async () => {
+    const page = {
+      items: [
+        {
+          id: "evt-1",
+          conversationId: "c1",
+          conversationTitle: "Fourier transforms",
+          turnId: "turn-1",
+          model: "us.anthropic.claude-sonnet-5",
+          inputTokens: 1200,
+          outputTokens: 400,
+          ttsChars: 900,
+          costMicros: 12_345,
+          createdAt: "2026-07-19T12:00:00.000Z",
+        },
+      ],
+      total: 1,
+      limit: 20,
+      offset: 0,
+    };
+    listUsage.mockResolvedValue(page);
+
+    const res = await appWith({ id: "u1" }).request("/credits/usage");
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual(page);
+    expect(listUsage).toHaveBeenCalledWith({
+      userId: "u1",
+      limit: 20,
+      offset: 0,
+    });
+  });
+
+  it("passes limit and offset through", async () => {
+    listUsage.mockResolvedValue(emptyPage);
+
+    await appWith({ id: "u1" }).request("/credits/usage?limit=5&offset=40");
+
+    expect(listUsage).toHaveBeenCalledWith({
+      userId: "u1",
+      limit: 5,
+      offset: 40,
+    });
+  });
+
+  it("clamps out-of-range values and defaults malformed ones", async () => {
+    listUsage.mockResolvedValue(emptyPage);
+
+    await appWith({ id: "u1" }).request("/credits/usage?limit=9999&offset=-3");
+    expect(listUsage).toHaveBeenCalledWith({
+      userId: "u1",
+      limit: 100,
+      offset: 0,
+    });
+
+    await appWith({ id: "u1" }).request("/credits/usage?limit=abc&offset=xyz");
+    expect(listUsage).toHaveBeenLastCalledWith({
+      userId: "u1",
+      limit: 20,
+      offset: 0,
+    });
   });
 });

--- a/apps/api/src/__tests__/credits.service.test.ts
+++ b/apps/api/src/__tests__/credits.service.test.ts
@@ -7,10 +7,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const USER_CREDITS = { __table: "user_credits" };
 const USAGE_EVENT = { __table: "usage_event" };
+const CONVERSATION = { __table: "conversation", id: "id", title: "title" };
 
 const h = vi.hoisted(() => ({
   findFirst: vi.fn(),
   selectRows: vi.fn(() => [{ total: "0" }]),
+  /** Queued results for chained selects (listUsage); falls back to selectRows. */
+  selectQueue: [] as unknown[],
   usageReturning: vi.fn(() => [{ id: "evt-1" }]),
   updateWhere: vi.fn(() => Promise.resolve(undefined)),
   insertCalls: [] as Array<{ table: unknown; values: unknown }>,
@@ -24,7 +27,26 @@ vi.mock("@animus/core/env", () => ({
 vi.mock("@animus/db", () => ({
   db: {
     query: { userCredits: { findFirst: h.findFirst } },
-    select: () => ({ from: () => Promise.resolve(h.selectRows()) }),
+    // A chainable, thenable select: every chain method returns the builder and
+    // awaiting it resolves the next queued result (or the legacy selectRows).
+    select: () => {
+      const chain = {
+        from: () => chain,
+        where: () => chain,
+        orderBy: () => chain,
+        limit: () => chain,
+        offset: () => chain,
+        then: (
+          resolve: (value: unknown) => unknown,
+          reject?: (error: unknown) => unknown
+        ) => {
+          const result =
+            h.selectQueue.length > 0 ? h.selectQueue.shift() : h.selectRows();
+          return Promise.resolve(result).then(resolve, reject);
+        },
+      };
+      return chain;
+    },
     insert: (table: unknown) => ({
       values: (values: unknown) => {
         h.insertCalls.push({ table, values });
@@ -40,19 +62,24 @@ vi.mock("@animus/db", () => ({
     }),
     update: () => ({ set: () => ({ where: h.updateWhere }) }),
   },
+  conversation: CONVERSATION,
+  count: vi.fn(() => ({ count: true })),
+  desc: vi.fn((column) => ({ desc: column })),
   eq: vi.fn((left, right) => ({ eq: [left, right] })),
+  inArray: vi.fn((column, values) => ({ inArray: [column, values] })),
   sqlExpr: vi.fn(() => ({ sql: true })),
   userCredits: USER_CREDITS,
   usageEvent: USAGE_EVENT,
 }));
 
-const { getOrCreateCredits, settleUsage } = await import(
+const { getOrCreateCredits, listUsage, settleUsage } = await import(
   "../services/credits.ts"
 );
 
 beforeEach(() => {
   vi.clearAllMocks();
   h.selectRows.mockReturnValue([{ total: "0" }]);
+  h.selectQueue.length = 0;
   h.usageReturning.mockReturnValue([{ id: "evt-1" }]);
   h.updateWhere.mockResolvedValue(undefined);
   h.insertCalls.length = 0;
@@ -184,5 +211,83 @@ describe("settleUsage", () => {
     });
     expect(charged).toBe(0);
     expect(h.updateWhere).not.toHaveBeenCalled();
+  });
+});
+
+describe("listUsage", () => {
+  const CREATED = new Date("2026-07-19T12:00:00Z");
+
+  const row = (overrides: Record<string, unknown>) => ({
+    id: "evt-1",
+    userId: "u1",
+    conversationId: null,
+    turnId: "t1",
+    model: null,
+    inputTokens: 0,
+    outputTokens: 0,
+    ttsChars: 0,
+    costMicros: 0,
+    createdAt: CREATED,
+    ...overrides,
+  });
+
+  it("maps rows, attaches surviving conversation titles, and reports total", async () => {
+    h.selectQueue.push(
+      [
+        row({
+          id: "evt-1",
+          conversationId: "c1",
+          turnId: "t1",
+          model: "us.anthropic.claude-sonnet-5",
+          inputTokens: 1200,
+          outputTokens: 300,
+          ttsChars: 900,
+          costMicros: 12_345,
+        }),
+        row({
+          id: "evt-2",
+          conversationId: "c-deleted",
+          turnId: "t2",
+          ttsChars: 50,
+          costMicros: 15,
+        }),
+      ],
+      [{ total: 2 }],
+      [{ id: "c1", title: "Fourier transforms" }]
+    );
+
+    const page = await listUsage({ userId: "u1", limit: 20, offset: 0 });
+
+    expect(page.total).toBe(2);
+    expect(page.limit).toBe(20);
+    expect(page.offset).toBe(0);
+    expect(page.items[0]).toEqual({
+      id: "evt-1",
+      conversationId: "c1",
+      conversationTitle: "Fourier transforms",
+      turnId: "t1",
+      model: "us.anthropic.claude-sonnet-5",
+      inputTokens: 1200,
+      outputTokens: 300,
+      ttsChars: 900,
+      costMicros: 12_345,
+      createdAt: CREATED.toISOString(),
+    });
+    // Deleted conversation: id survives, title is null, BYOK model is null.
+    expect(page.items[1]).toMatchObject({
+      conversationId: "c-deleted",
+      conversationTitle: null,
+      model: null,
+    });
+  });
+
+  it("returns an empty page without querying titles when there are no rows", async () => {
+    h.selectQueue.push([], [{ total: 0 }]);
+
+    const page = await listUsage({ userId: "u1", limit: 10, offset: 40 });
+
+    expect(page).toEqual({ items: [], total: 0, limit: 10, offset: 40 });
+    // Only the rows + count selects ran — nothing left unconsumed.
+    expect(h.selectQueue.length).toBe(0);
   });
 });

--- a/apps/api/src/__tests__/credits.service.test.ts
+++ b/apps/api/src/__tests__/credits.service.test.ts
@@ -36,6 +36,7 @@ vi.mock("@animus/db", () => ({
         orderBy: () => chain,
         limit: () => chain,
         offset: () => chain,
+        // biome-ignore lint/suspicious/noThenProperty: intentionally thenable — drizzle's query builder is awaited directly, so the mock must be too.
         then: (
           resolve: (value: unknown) => unknown,
           reject?: (error: unknown) => unknown

--- a/apps/api/src/routes/credits.ts
+++ b/apps/api/src/routes/credits.ts
@@ -1,10 +1,12 @@
-/** The caller's credit balance. Seeds the balance row with the free grant on
- * first read. Authenticated — a user only ever sees their own balance. */
+/** The caller's credit balance and usage ledger. The balance read seeds the
+ * row with the free grant on first touch. Authenticated — a user only ever
+ * sees their own rows. */
 
 import { Hono } from "hono";
+import { z } from "zod";
 import { userId } from "../lib/user.ts";
 import { requireAuth } from "../middleware/auth.ts";
-import { getOrCreateCredits } from "../services/credits.ts";
+import { getOrCreateCredits, listUsage } from "../services/credits.ts";
 import type { AppEnv } from "../types.ts";
 
 export const creditsRoute = new Hono<AppEnv>();
@@ -14,4 +16,27 @@ creditsRoute.use("*", requireAuth);
 creditsRoute.get("/", async (c) => {
   const balance = await getOrCreateCredits(userId(c));
   return c.json(balance);
+});
+
+/** Malformed values fall back to the defaults; out-of-range ones clamp. */
+const UsageQuerySchema = z.object({
+  limit: z.coerce
+    .number()
+    .int()
+    .catch(20)
+    .transform((n) => Math.min(Math.max(n, 1), 100)),
+  offset: z.coerce
+    .number()
+    .int()
+    .catch(0)
+    .transform((n) => Math.max(n, 0)),
+});
+
+creditsRoute.get("/usage", async (c) => {
+  const { limit, offset } = UsageQuerySchema.parse({
+    limit: c.req.query("limit") ?? 20,
+    offset: c.req.query("offset") ?? 0,
+  });
+  const page = await listUsage({ userId: userId(c), limit, offset });
+  return c.json(page);
 });

--- a/apps/api/src/services/credits.ts
+++ b/apps/api/src/services/credits.ts
@@ -14,9 +14,20 @@ import {
   FREE_GRANT_MICROS,
   MICROS_PER_DOLLAR,
   ttsCostMicros,
+  type UsageList,
 } from "@animus/core";
 import { getServerEnv } from "@animus/core/env";
-import { db, eq, sqlExpr, usageEvent, userCredits } from "@animus/db";
+import {
+  conversation,
+  count,
+  db,
+  desc,
+  eq,
+  inArray,
+  sqlExpr,
+  usageEvent,
+  userCredits,
+} from "@animus/db";
 
 function toBalance(balanceMicros: number): CreditsBalance {
   return { balanceMicros, grantMicros: FREE_GRANT_MICROS };
@@ -128,4 +139,68 @@ export async function settleUsage(input: SettleUsageInput): Promise<number> {
     .where(eq(userCredits.userId, input.userId));
 
   return costMicros;
+}
+
+export interface ListUsageInput {
+  limit: number;
+  offset: number;
+  userId: string;
+}
+
+/** A page of the caller's usage ledger, newest first, with conversation titles
+ * attached where the conversation still exists (the ledger keeps the plain id
+ * after deletion, so cost history survives). */
+export async function listUsage({
+  userId,
+  limit,
+  offset,
+}: ListUsageInput): Promise<UsageList> {
+  const [rows, totalRows] = await Promise.all([
+    db
+      .select()
+      .from(usageEvent)
+      .where(eq(usageEvent.userId, userId))
+      .orderBy(desc(usageEvent.createdAt), desc(usageEvent.id))
+      .limit(limit)
+      .offset(offset),
+    db
+      .select({ total: count() })
+      .from(usageEvent)
+      .where(eq(usageEvent.userId, userId)),
+  ]);
+
+  const conversationIds = [
+    ...new Set(
+      rows
+        .map((row) => row.conversationId)
+        .filter((id): id is string => id !== null)
+    ),
+  ];
+  const titles = conversationIds.length
+    ? await db
+        .select({ id: conversation.id, title: conversation.title })
+        .from(conversation)
+        .where(inArray(conversation.id, conversationIds))
+    : [];
+  const titleById = new Map(titles.map((row) => [row.id, row.title]));
+
+  return {
+    items: rows.map((row) => ({
+      id: row.id,
+      conversationId: row.conversationId,
+      conversationTitle: row.conversationId
+        ? (titleById.get(row.conversationId) ?? null)
+        : null,
+      turnId: row.turnId,
+      model: row.model,
+      inputTokens: row.inputTokens,
+      outputTokens: row.outputTokens,
+      ttsChars: row.ttsChars,
+      costMicros: row.costMicros,
+      createdAt: row.createdAt.toISOString(),
+    })),
+    total: totalRows[0]?.total ?? 0,
+    limit,
+    offset,
+  };
 }

--- a/apps/web/components.json
+++ b/apps/web/components.json
@@ -23,6 +23,7 @@
 	},
 	"registries": {
 		"@efferd": "https://efferd.com/r/{style}/{name}.json",
-		"@react-bits": "https://reactbits.dev/r/{name}.json"
+		"@react-bits": "https://reactbits.dev/r/{name}.json",
+		"@reui": "https://reui.io/r/{style}/{name}.json"
 	}
 }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -14,6 +14,7 @@ import { AccountSection } from "@/features/settings/components/account-section";
 import { GenerationSection } from "@/features/settings/components/generation-section";
 import { SecretsSection } from "@/features/settings/components/secrets-section";
 import { SettingsLayout } from "@/features/settings/components/settings-layout";
+import { UsageSection } from "@/features/settings/components/usage-section";
 import { AuthPage } from "@/pages/auth-page";
 import { LandingPage } from "@/pages/landing-page";
 import { NotFoundPage } from "@/pages/not-found-page";
@@ -70,6 +71,7 @@ function App() {
 						/>
 						<Route element={<AccountSection />} path="account" />
 						<Route element={<GenerationSection />} path="generation" />
+						<Route element={<UsageSection />} path="usage" />
 						<Route element={<SecretsSection />} path="secrets" />
 					</Route>
 				</Route>

--- a/apps/web/src/components/balance-section.tsx
+++ b/apps/web/src/components/balance-section.tsx
@@ -4,7 +4,7 @@
  * two places: the profile dropdown ("menu") and the account page ("card"). */
 
 import { type CreditsBalance, formatUsd } from "@animus/core";
-import { KeyIcon } from "lucide-react";
+import { KeyIcon, ReceiptTextIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
 	Card,
@@ -42,11 +42,14 @@ export function BalanceSection({
 	balance,
 	fraction,
 	onNavigateToKeys,
+	onNavigateToUsage,
 }: {
 	variant: "menu" | "card";
 	balance: CreditsBalance;
 	fraction: number;
 	onNavigateToKeys: () => void;
+	/** Shows a "View usage" button into the usage ledger when provided. */
+	onNavigateToUsage?: () => void;
 }) {
 	if (variant === "menu") {
 		return (
@@ -65,6 +68,17 @@ export function BalanceSection({
 					<KeyIcon />
 					Bring your own key
 				</Button>
+				{onNavigateToUsage ? (
+					<Button
+						className="mt-1.5 w-full"
+						onClick={onNavigateToUsage}
+						size="sm"
+						variant="outline"
+					>
+						<ReceiptTextIcon />
+						View usage
+					</Button>
+				) : null}
 			</div>
 		);
 	}
@@ -85,10 +99,18 @@ export function BalanceSection({
 			</CardHeader>
 			<CardContent className="space-y-4">
 				<LineGauge fraction={fraction} />
-				<Button onClick={onNavigateToKeys} variant="outline">
-					<KeyIcon data-icon="inline-start" />
-					Bring your own key
-				</Button>
+				<div className="flex flex-wrap gap-2">
+					<Button onClick={onNavigateToKeys} variant="outline">
+						<KeyIcon data-icon="inline-start" />
+						Bring your own key
+					</Button>
+					{onNavigateToUsage ? (
+						<Button onClick={onNavigateToUsage} variant="outline">
+							<ReceiptTextIcon data-icon="inline-start" />
+							View usage
+						</Button>
+					) : null}
+				</div>
 			</CardContent>
 		</Card>
 	);

--- a/apps/web/src/components/layout/nav-user.tsx
+++ b/apps/web/src/components/layout/nav-user.tsx
@@ -41,6 +41,11 @@ export function NavUser() {
 		navigate("/settings/secrets");
 	}
 
+	function goToUsage() {
+		setOpen(false);
+		navigate("/settings/usage");
+	}
+
 	return (
 		<DropdownMenu onOpenChange={setOpen} open={open}>
 			<DropdownMenuTrigger asChild>
@@ -105,6 +110,7 @@ export function NavUser() {
 							balance={balance}
 							fraction={fraction}
 							onNavigateToKeys={goToKeys}
+							onNavigateToUsage={goToUsage}
 							variant="menu"
 						/>
 					</>

--- a/apps/web/src/components/ui/table.tsx
+++ b/apps/web/src/components/ui/table.tsx
@@ -1,0 +1,114 @@
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Table({ className, ...props }: React.ComponentProps<"table">) {
+	return (
+		<div
+			data-slot="table-container"
+			className="relative w-full overflow-x-auto"
+		>
+			<table
+				data-slot="table"
+				className={cn("w-full caption-bottom text-sm", className)}
+				{...props}
+			/>
+		</div>
+	);
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
+	return (
+		<thead
+			data-slot="table-header"
+			className={cn("[&_tr]:border-b", className)}
+			{...props}
+		/>
+	);
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
+	return (
+		<tbody
+			data-slot="table-body"
+			className={cn("[&_tr:last-child]:border-0", className)}
+			{...props}
+		/>
+	);
+}
+
+function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
+	return (
+		<tfoot
+			data-slot="table-footer"
+			className={cn(
+				"border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
+	return (
+		<tr
+			data-slot="table-row"
+			className={cn(
+				"border-b transition-colors hover:bg-muted/50 has-aria-expanded:bg-muted/50 data-[state=selected]:bg-muted",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function TableHead({ className, ...props }: React.ComponentProps<"th">) {
+	return (
+		<th
+			data-slot="table-head"
+			className={cn(
+				"h-10 px-2 text-left align-middle font-medium whitespace-nowrap text-foreground [&:has([role=checkbox])]:pr-0",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<"td">) {
+	return (
+		<td
+			data-slot="table-cell"
+			className={cn(
+				"p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function TableCaption({
+	className,
+	...props
+}: React.ComponentProps<"caption">) {
+	return (
+		<caption
+			data-slot="table-caption"
+			className={cn("mt-4 text-sm text-muted-foreground", className)}
+			{...props}
+		/>
+	);
+}
+
+export {
+	Table,
+	TableBody,
+	TableCaption,
+	TableCell,
+	TableFooter,
+	TableHead,
+	TableHeader,
+	TableRow,
+};

--- a/apps/web/src/features/settings/components/account-section.tsx
+++ b/apps/web/src/features/settings/components/account-section.tsx
@@ -114,6 +114,7 @@ export function AccountSection() {
 						balance={balance}
 						fraction={fraction}
 						onNavigateToKeys={() => navigate("/settings/secrets")}
+						onNavigateToUsage={() => navigate("/settings/usage")}
 						variant="card"
 					/>
 				) : null}

--- a/apps/web/src/features/settings/components/generation-section.tsx
+++ b/apps/web/src/features/settings/components/generation-section.tsx
@@ -93,7 +93,7 @@ export function GenerationSection() {
 					description="The look of the rendered video canvas."
 					title="Video theme"
 				>
-					<div className="flex gap-1 rounded-sm border p-0.5">
+					<div className="flex w-fit gap-1 rounded-sm border p-0.5">
 						{VIDEO_THEMES.map((option) => (
 							<button
 								aria-pressed={config.videoTheme === option}

--- a/apps/web/src/features/settings/components/secrets-section.tsx
+++ b/apps/web/src/features/settings/components/secrets-section.tsx
@@ -5,7 +5,6 @@
  * plaintext never comes back, only a masked preview. */
 
 import {
-	formatUsd,
 	type LlmKeyPreview,
 	type ProviderId,
 	type ProviderKeys,
@@ -16,13 +15,6 @@ import { EyeIcon, EyeOffIcon } from "lucide-react";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
-import {
-	Card,
-	CardContent,
-	CardDescription,
-	CardHeader,
-	CardTitle,
-} from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import {
 	Select,
@@ -31,7 +23,6 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from "@/components/ui/select";
-import { useCredits } from "@/hooks/use-credits";
 import { ApiError, apiFetch } from "@/lib/api";
 import { notifyCreditsChanged } from "@/lib/credit-events";
 import { PROVIDERS } from "../data/providers";
@@ -102,37 +93,6 @@ function SavedKeyRow({
 				Remove
 			</Button>
 		</div>
-	);
-}
-
-function CreditsCard() {
-	const { balance, fraction } = useCredits();
-	if (!balance) {
-		return null;
-	}
-	return (
-		<Card>
-			<CardHeader>
-				<CardTitle className="flex items-center justify-between">
-					<span>Balance</span>
-					<span className="tabular-nums">
-						{formatUsd(balance.balanceMicros)}
-					</span>
-				</CardTitle>
-				<CardDescription>
-					Free credits for generating on our models. Bring your own key below to
-					keep going for free once they run out.
-				</CardDescription>
-			</CardHeader>
-			<CardContent>
-				<div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
-					<div
-						className="h-full rounded-full bg-primary transition-[width] duration-500"
-						style={{ width: `${fraction * 100}%` }}
-					/>
-				</div>
-			</CardContent>
-		</Card>
 	);
 }
 
@@ -270,11 +230,9 @@ export function SecretsSection() {
 	return (
 		<div className="space-y-8">
 			<SectionHeading
-				description="Bring your own key to generate for free — a brought key runs on your account and isn't metered."
-				title="Credits & keys"
+				description="Bring your own key to generate for free. A brought key runs on your account and isn't metered."
+				title="Bring your own keys"
 			/>
-
-			<CreditsCard />
 
 			<div className="space-y-4">
 				<div>

--- a/apps/web/src/features/settings/components/settings-layout.tsx
+++ b/apps/web/src/features/settings/components/settings-layout.tsx
@@ -2,7 +2,13 @@
  * column (the active section renders into the Outlet). Full-height layout,
  * separate from the studio shell. */
 
-import { ChevronLeftIcon, KeyIcon, SlidersIcon, UserIcon } from "lucide-react";
+import {
+	ChevronLeftIcon,
+	KeyIcon,
+	ReceiptTextIcon,
+	SlidersIcon,
+	UserIcon,
+} from "lucide-react";
 import { Link, NavLink, Outlet, useLocation } from "react-router";
 import { Wordmark } from "@/components/brand/wordmark";
 import { useDocumentTitle } from "@/hooks/use-document-title";
@@ -11,7 +17,8 @@ import { cn } from "@/lib/utils";
 const SECTIONS = [
 	{ to: "/settings/account", label: "Account", icon: UserIcon },
 	{ to: "/settings/generation", label: "Generation", icon: SlidersIcon },
-	{ to: "/settings/secrets", label: "API keys", icon: KeyIcon },
+	{ to: "/settings/usage", label: "Usage", icon: ReceiptTextIcon },
+	{ to: "/settings/secrets", label: "BYOK", icon: KeyIcon },
 ];
 
 export function SettingsLayout() {
@@ -56,7 +63,7 @@ export function SettingsLayout() {
 				</nav>
 			</aside>
 			<main className="min-h-0 flex-1 overflow-y-auto">
-				<div className="mx-auto w-full max-w-2xl px-6 py-10">
+				<div className="mx-auto w-full max-w-4xl px-6 py-10">
 					<Outlet />
 				</div>
 			</main>

--- a/apps/web/src/features/settings/components/usage-section.tsx
+++ b/apps/web/src/features/settings/components/usage-section.tsx
@@ -1,0 +1,262 @@
+/** The usage ledger: the balance card plus a paginated table of every settled
+ * turn — when, which conversation, which model, tokens, TTS characters, and
+ * what it cost. The itemized view of where the credits went. */
+
+import {
+	formatUsdPrecise,
+	type UsageEventItem,
+	type UsageList,
+} from "@animus/core";
+import { Anthropic, Bedrock, ElevenLabs, Gemini, OpenAI } from "@lobehub/icons";
+import { KeyIcon } from "lucide-react";
+import { useEffect, useState } from "react";
+import { Link, useNavigate } from "react-router";
+import { BalanceSection } from "@/components/balance-section";
+import { Button } from "@/components/ui/button";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
+import { useCredits } from "@/hooks/use-credits";
+import { apiFetch } from "@/lib/api";
+import { SectionHeading } from "./section-heading";
+
+const PAGE_SIZE = 50;
+
+/** Provider brand icon for a metered model id (Bedrock profile ids embed the
+ * vendor, BYOK model ids start with it). */
+function modelIcon(model: string) {
+	if (/anthropic|claude/i.test(model)) {
+		return Anthropic;
+	}
+	if (/openai|gpt|^o\d/i.test(model)) {
+		return OpenAI;
+	}
+	if (/google|gemini/i.test(model)) {
+		return Gemini;
+	}
+	return Bedrock;
+}
+
+/** The vendor-prefixed Bedrock profile id, shortened to the model name
+ * (`us.anthropic.claude-sonnet-5` → `claude-sonnet-5`). */
+function shortModel(model: string): string {
+	const lastSegment = model.split(".").at(-1);
+	return lastSegment ?? model;
+}
+
+function formatWhen(iso: string): string {
+	const date = new Date(iso);
+	if (Number.isNaN(date.getTime())) {
+		return "—";
+	}
+	return date.toLocaleString(undefined, {
+		month: "short",
+		day: "numeric",
+		hour: "2-digit",
+		minute: "2-digit",
+	});
+}
+
+function formatCount(value: number): string {
+	return value === 0 ? "—" : value.toLocaleString();
+}
+
+function ModelCell({ model }: { model: string | null }) {
+	if (!model) {
+		return (
+			<span className="flex items-center gap-1.5 text-muted-foreground">
+				<KeyIcon aria-hidden="true" className="size-3.5 shrink-0" />
+				Your key
+			</span>
+		);
+	}
+	const Icon = modelIcon(model);
+	return (
+		<span className="flex items-center gap-1.5">
+			<Icon aria-hidden="true" className="shrink-0" size={14} />
+			<span className="max-w-40 truncate" title={model}>
+				{shortModel(model)}
+			</span>
+		</span>
+	);
+}
+
+function TtsCell({ chars }: { chars: number }) {
+	if (chars === 0) {
+		return <span className="text-muted-foreground">—</span>;
+	}
+	return (
+		<span className="inline-flex items-center gap-1.5 tabular-nums">
+			<ElevenLabs aria-hidden="true" className="shrink-0" size={12} />
+			{chars.toLocaleString()}
+		</span>
+	);
+}
+
+function ConversationCell({ item }: { item: UsageEventItem }) {
+	const label =
+		item.conversationTitle ??
+		(item.conversationId ? `${item.conversationId.slice(0, 8)}…` : "—");
+	return (
+		<div className="min-w-0">
+			{item.conversationId && item.conversationTitle ? (
+				<Link
+					className="block max-w-48 truncate hover:underline"
+					title={item.conversationTitle}
+					to={`/studio/c/${item.conversationId}`}
+				>
+					{label}
+				</Link>
+			) : (
+				<span className="block max-w-48 truncate text-muted-foreground">
+					{label}
+				</span>
+			)}
+			<span
+				className="block truncate font-mono text-[10px] text-muted-foreground"
+				title={item.turnId}
+			>
+				{item.turnId.slice(0, 13)}…
+			</span>
+		</div>
+	);
+}
+
+export function UsageSection() {
+	const navigate = useNavigate();
+	const { balance, fraction } = useCredits();
+	const [page, setPage] = useState<UsageList | null>(null);
+	const [offset, setOffset] = useState(0);
+	const [loading, setLoading] = useState(true);
+
+	useEffect(() => {
+		let active = true;
+		setLoading(true);
+		apiFetch<UsageList>(
+			`/api/credits/usage?limit=${PAGE_SIZE}&offset=${offset}`,
+		)
+			.then((data) => {
+				if (active) {
+					setPage(data);
+				}
+			})
+			.catch(() => {
+				// Leave the previous page (or the empty state) in place.
+			})
+			.finally(() => {
+				if (active) {
+					setLoading(false);
+				}
+			});
+		return () => {
+			active = false;
+		};
+	}, [offset]);
+
+	const items = page?.items ?? [];
+	const total = page?.total ?? 0;
+	const from = total === 0 ? 0 : offset + 1;
+	const to = Math.min(offset + PAGE_SIZE, total);
+
+	return (
+		<div className="space-y-8">
+			<SectionHeading
+				description="Every metered turn, itemized: what ran, on which conversation, and what it cost."
+				title="Usage"
+			/>
+
+			{balance ? (
+				<BalanceSection
+					balance={balance}
+					fraction={fraction}
+					onNavigateToKeys={() => navigate("/settings/secrets")}
+					variant="card"
+				/>
+			) : null}
+
+			<div className="space-y-3">
+				<div className="rounded-md border">
+					<Table className="text-xs">
+						<TableHeader>
+							<TableRow>
+								<TableHead className="h-8 text-xs">Date</TableHead>
+								<TableHead className="h-8 text-xs">Conversation</TableHead>
+								<TableHead className="h-8 text-xs">Model</TableHead>
+								<TableHead className="h-8 text-xs">Input</TableHead>
+								<TableHead className="h-8 text-xs">Output</TableHead>
+								<TableHead className="h-8 text-xs">TTS</TableHead>
+								<TableHead className="h-8 text-xs">Cost</TableHead>
+							</TableRow>
+						</TableHeader>
+						<TableBody>
+							{items.map((item) => (
+								<TableRow key={item.id}>
+									<TableCell className="whitespace-nowrap py-1.5 text-muted-foreground">
+										{formatWhen(item.createdAt)}
+									</TableCell>
+									<TableCell className="py-1.5">
+										<ConversationCell item={item} />
+									</TableCell>
+									<TableCell className="whitespace-nowrap py-1.5">
+										<ModelCell model={item.model} />
+									</TableCell>
+									<TableCell className="whitespace-nowrap py-1.5 tabular-nums">
+										{formatCount(item.inputTokens)}
+									</TableCell>
+									<TableCell className="whitespace-nowrap py-1.5 tabular-nums">
+										{formatCount(item.outputTokens)}
+									</TableCell>
+									<TableCell className="whitespace-nowrap py-1.5">
+										<TtsCell chars={item.ttsChars} />
+									</TableCell>
+									<TableCell className="whitespace-nowrap py-1.5 font-medium tabular-nums">
+										{formatUsdPrecise(item.costMicros)}
+									</TableCell>
+								</TableRow>
+							))}
+							{items.length === 0 ? (
+								<TableRow className="hover:bg-transparent">
+									<TableCell
+										className="py-10 text-center text-muted-foreground"
+										colSpan={7}
+									>
+										{loading
+											? "Loading usage…"
+											: "No usage yet. Metered turns will appear here."}
+									</TableCell>
+								</TableRow>
+							) : null}
+						</TableBody>
+					</Table>
+				</div>
+
+				<div className="flex items-center justify-between text-muted-foreground text-xs">
+					<span>{total === 0 ? "0 entries" : `${from}–${to} of ${total}`}</span>
+					<div className="flex gap-2">
+						<Button
+							disabled={loading || offset === 0}
+							onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
+							size="sm"
+							variant="outline"
+						>
+							Previous
+						</Button>
+						<Button
+							disabled={loading || offset + PAGE_SIZE >= total}
+							onClick={() => setOffset(offset + PAGE_SIZE)}
+							size="sm"
+							variant="outline"
+						>
+							Next
+						</Button>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/packages/core/src/credits.ts
+++ b/packages/core/src/credits.ts
@@ -16,3 +16,34 @@ export const CreditsBalanceSchema = z.object({
   grantMicros: z.number().int(),
 });
 export type CreditsBalance = z.infer<typeof CreditsBalanceSchema>;
+
+/** One settled turn in the usage ledger (`GET /api/credits/usage`). */
+export const UsageEventItemSchema = z.object({
+  id: z.string(),
+  /** The conversation the turn belonged to; kept after deletion. */
+  conversationId: z.string().nullable(),
+  /** Title when the conversation still exists; null once it's deleted. */
+  conversationTitle: z.string().nullable(),
+  /** The per-request turn id the settlement was keyed on. */
+  turnId: z.string(),
+  /** Metered LLM model id; null when the LLM ran on the user's own key. */
+  model: z.string().nullable(),
+  inputTokens: z.number().int(),
+  outputTokens: z.number().int(),
+  ttsChars: z.number().int(),
+  /** Total settled cost of the turn in micro-USD. */
+  costMicros: z.number().int(),
+  /** ISO timestamp of the settlement. */
+  createdAt: z.string(),
+});
+export type UsageEventItem = z.infer<typeof UsageEventItemSchema>;
+
+/** Paginated usage ledger page, newest first. */
+export const UsageListSchema = z.object({
+  items: z.array(UsageEventItemSchema),
+  /** Total ledger rows for the user (for page controls). */
+  total: z.number().int(),
+  limit: z.number().int(),
+  offset: z.number().int(),
+});
+export type UsageList = z.infer<typeof UsageListSchema>;

--- a/packages/core/src/pricing.ts
+++ b/packages/core/src/pricing.ts
@@ -109,3 +109,11 @@ export function formatUsd(micros: number): string {
   const usd = Math.max(0, microsToUsd(micros));
   return `$${usd.toFixed(2)}`;
 }
+
+/** Format a micro-USD cost with sub-cent precision, e.g. `$0.0132` — per-turn
+ * ledger amounts are usually fractions of a cent, which `formatUsd` would
+ * flatten to `$0.00`. Dollar-plus amounts keep the familiar two decimals. */
+export function formatUsdPrecise(micros: number): string {
+  const usd = Math.max(0, microsToUsd(micros));
+  return usd >= 1 ? `$${usd.toFixed(2)}` : `$${usd.toFixed(4)}`;
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -4,10 +4,12 @@
 export {
   and,
   asc,
+  count,
   desc,
   eq,
   exists,
   ilike,
+  inArray,
   or,
   // drizzle's SQL-fragment builder (for aggregates / raw arithmetic). Named to
   // avoid colliding with the postgres.js client also exported as `sql`.


### PR DESCRIPTION
Transparency pass on the settings: every metered turn is now visible, itemized, to the user.

- **API**: `GET /api/credits/usage` — paginated ledger (zod-clamped limit/offset), newest first, conversation titles attached while the conversation exists (the ledger keeps the plain id after deletion so cost history survives). Route + service tests.
- **Contracts**: `UsageEventItem`/`UsageList` in `@animus/core`, `formatUsdPrecise` for sub-cent per-turn amounts, `count`/`inArray` exports in `@animus/db`.
- **Web**: new **Usage** settings tab — balance card + compact ReUI/shadcn table (date, conversation link with turn id, model with provider icon, input/output tokens, TTS chars with the ElevenLabs mark, cost), 50 rows/page with Previous/Next.
- **Settings restructure**: "API keys" → **BYOK** (its duplicate balance card removed), settings column widened to max-w-4xl, **View usage** buttons on the account balance card and the header avatar menu, mobile video-theme switch no longer stretches full-width.

Note: the ledger only contains metered turns (fully-BYOK turns are never settled, by design). All gates pass: typecheck, ultracite, knip, vitest (346).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a usage ledger with a new settings tab and API so users can see every metered turn and its cost. Also reorganized settings: renamed API keys to BYOK, widened the layout, and added “View usage” entry points.

- New Features
  - API: `GET /api/credits/usage` returns a paginated ledger (clamped `limit`/`offset`), newest first, with conversation titles when available. Includes route + service tests.
  - Contracts: Added `UsageEventItem`/`UsageList` and `formatUsdPrecise` in `@animus/core`; exported `count`/`inArray` from `@animus/db`.
  - Web: New Usage tab with balance card and compact table (date, conversation link + turn id, model with provider icon, input/output tokens, TTS chars with ElevenLabs, cost). 50 rows per page.

- Refactors
  - Renamed “API keys” to BYOK and removed its duplicate balance card.
  - Widened settings content to max-w-4xl.
  - Added “View usage” buttons in the balance card and avatar menu; fixed mobile video-theme switch width.

<sup>Written for commit d4f62e0dd53d3d571c52bef1813365c49f93e856. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/KacemMathlouthi/animus/pull/38?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

