### PR TITLE
fix: share links show no OG image in prod — inject meta at /v/:token

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,23 +171,24 @@ Cross-package "does it compile" = `bun run typecheck`.
   the narration (`tracker.duration`, bookmarks). The ElevenLabs key is injected into
   the render sandbox via `envVars`. Background music is mixed under the narration in
   the post-render ffmpeg step.
-- **Link previews & the SPA meta-injection seam (partially resolved).** A static SPA
+- **Link previews & the SPA meta-injection seam (resolved).** A static SPA
   serves one `index.html` for every route, so per-share Open Graph / Twitter meta
   must be written **server-side at the real `/v/:token` URL** — crawlers don't run
   JS. The durable, deployment-agnostic parts live in `@animus/core`
   (`buildShareCardSvg`, `buildShareMetaTags`, `injectShareMeta`) and in the public
   API endpoints (`GET /api/share/:token/og.png` PNG card, `…/video.mp4` presigned
   redirect for `og:video`, `…/embed` iframe for `twitter:player`) — these never
-  change with hosting. The **only** hosting-coupled piece is the *injection layer*:
-  today it's a **Vite dev plugin** (`apps/web/plugins/share-meta.ts`) + an `/api`
-  proxy in `vite.config.ts`, both of which exist only under `vite dev`. In prod that
-  becomes an **edge function / meta-injecting reverse proxy / the API serving
-  `/v/:token`** (or vanishes entirely on an SSR migration), and it reuses the same
-  pure core builders — so the swap is ~30 lines of glue, not a rebuild. The
-  single-origin half of this is now **done in prod**: web + API sit behind
-  `tryanimus.app` (the `/api` rewrite), so external viewers can play shared
-  videos. Still open: server-side per-share meta injection at `/v/:token` for
-  crawlers (the edge-function glue).
+  change with hosting. The **only** hosting-coupled piece is the *injection layer*,
+  and both halves now exist: in dev a **Vite dev plugin**
+  (`apps/web/plugins/share-meta.ts`) + an `/api` proxy in `vite.config.ts`; in
+  prod the API's **`GET /api/share/:token/page`** route, which fetches the SPA
+  shell from `WEB_ORIGIN` (cached ~5 min), splices in the meta block, and is
+  wired to the real URL by a `/v/:token` rewrite in `apps/web/vercel.json`
+  (placed before the SPA fallback). Both layers reuse the same pure core
+  builders and the shared `SHARE_META_DESCRIPTION`. Humans still boot the SPA
+  as normal; unknown tokens get the plain shell. Single origin also done:
+  web + API sit behind `tryanimus.app` (the `/api` rewrite), so external
+  viewers can play shared videos.
 
 **Roadmap:** shell ✓ (settings backend; conversation persistence with generated
 titles; sidebar list/search/rename/delete) → streaming chat ✓ (`/api/chat` →
@@ -213,8 +214,8 @@ bundled Geist at the public `GET /api/share/:token/og.png`. Real link previews a
 served at the **natural `/v/:token` URL**: because a static SPA can't emit per-URL
 meta, per-share OG/Twitter tags (`buildShareMetaTags`/`injectShareMeta` in
 `@animus/core`) are injected into index.html server-side — a Vite dev plugin +
-`/api` proxy today so it works over a `cloudflared` tunnel, an edge function /
-meta-injecting proxy in prod (seam left; ties to the open hosting decision).
+`/api` proxy in dev, and in prod the API's `GET /api/share/:token/page` route
+behind a `/v/:token` rewrite (see the meta-injection decision above).
 Previews include `og:video` + a `twitter:player` iframe embed
 (`GET /api/share/:token/embed`) backed by a stable mp4 URL
 (`GET /api/share/:token/video.mp4` → presigned redirect), so they play inline

--- a/apps/api/src/__tests__/share.route.test.ts
+++ b/apps/api/src/__tests__/share.route.test.ts
@@ -9,6 +9,9 @@ const { getShareByToken, signDownloadUrl, signMediaUrl } = vi.hoisted(() => ({
 
 vi.mock("../lib/media.ts", () => ({ signDownloadUrl, signMediaUrl }));
 vi.mock("../services/shares.ts", () => ({ getShareByToken }));
+vi.mock("@animus/core/env", () => ({
+  getServerEnv: () => ({ webOrigin: "https://web.test" }),
+}));
 
 const { shareRoute } = await import("../routes/share.ts");
 
@@ -142,5 +145,76 @@ describe("GET /share/:token/embed", () => {
     getShareByToken.mockResolvedValue(null);
     const res = await app().request("/share/nope/embed");
     expect(res.status).toBe(404);
+  });
+});
+
+describe("GET /share/:token/page", () => {
+  const SHELL =
+    "<!doctype html><html><head><!-- share-meta:start --><title>animus</title><!-- share-meta:end --></head><body></body></html>";
+  const fetchShell = vi.fn();
+
+  vi.stubGlobal("fetch", fetchShell);
+
+  // NOTE: the SPA shell is cached at module level for 5 minutes, so test order
+  // matters here: the failure case runs first (a failed fetch is not cached),
+  // then the success cases prime and reuse the cache.
+  it("503s when the SPA shell cannot be fetched (and does not cache)", async () => {
+    fetchShell.mockResolvedValue(new Response("nope", { status: 500 }));
+    getShareByToken.mockResolvedValue(null);
+
+    const res = await app().request("/share/tok123/page");
+
+    expect(res.status).toBe(503);
+  });
+
+  it("serves the shell with injected per-share meta for a known token", async () => {
+    fetchShell.mockResolvedValue(new Response(SHELL, { status: 200 }));
+    getShareByToken.mockResolvedValue({
+      token: "tok123",
+      videoKey: "videos/conv1/Scene-ab12cd34.mp4",
+      title: 'My <"explainer">',
+    });
+
+    const res = await app().request("/share/tok123/page");
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/html");
+    expect(res.headers.get("cache-control")).toContain("max-age");
+    const html = await res.text();
+    // Meta is injected with absolute web-origin URLs and escaped content.
+    expect(html).toContain(
+      '<meta property="og:image" content="https://web.test/api/share/tok123/og.png"/>'
+    );
+    expect(html).toContain(
+      '<meta property="og:url" content="https://web.test/v/tok123"/>'
+    );
+    expect(html).toContain("My &lt;&quot;explainer&quot;&gt;");
+    // The SPA shell is intact around the injected block.
+    expect(html).toContain("<body></body>");
+    expect(fetchShell).toHaveBeenCalledWith(
+      "https://web.test/",
+      expect.anything()
+    );
+  });
+
+  it("serves the plain shell for an unknown token (SPA renders not-found)", async () => {
+    getShareByToken.mockResolvedValue(null);
+
+    const res = await app().request("/share/nope/page");
+
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).not.toContain("og:image");
+    expect(html).toContain("<body></body>");
+  });
+
+  it("reuses the cached shell instead of refetching per request", async () => {
+    fetchShell.mockClear();
+    getShareByToken.mockResolvedValue(null);
+
+    await app().request("/share/nope/page");
+    await app().request("/share/nope/page");
+
+    expect(fetchShell).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/routes/share.ts
+++ b/apps/api/src/routes/share.ts
@@ -4,7 +4,14 @@
  * authenticated `POST /api/media/share`; this route is read-only and never
  * exposes the underlying object key or conversation. */
 
-import { escapeHtml, PublicShareResponseSchema } from "@animus/core";
+import {
+  buildShareMetaTags,
+  escapeHtml,
+  injectShareMeta,
+  PublicShareResponseSchema,
+  SHARE_META_DESCRIPTION,
+} from "@animus/core";
+import { getServerEnv } from "@animus/core/env";
 import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
 import { signDownloadUrl, signMediaUrl } from "../lib/media.ts";
@@ -60,6 +67,61 @@ shareRoute.get("/:token/video.mp4", async (c) => {
   const url = await signMediaUrl(share.videoKey);
   c.header("Cache-Control", "public, max-age=300");
   return c.redirect(url, 302);
+});
+
+/** The SPA shell (index.html) fetched from the web origin, cached briefly —
+ * it only changes on a web deploy, and a crawler burst must not hammer the
+ * origin with one fetch per hit. */
+const SHELL_CACHE_TTL_MS = 5 * 60 * 1000;
+let shellCache: { html: string; fetchedAt: number } | null = null;
+
+async function fetchSpaShell(webOrigin: string): Promise<string> {
+  const now = Date.now();
+  if (shellCache && now - shellCache.fetchedAt < SHELL_CACHE_TTL_MS) {
+    return shellCache.html;
+  }
+  const res = await fetch(`${webOrigin}/`, {
+    headers: { accept: "text/html" },
+  });
+  if (!res.ok) {
+    throw new HTTPException(503, { message: "Share page unavailable" });
+  }
+  const html = await res.text();
+  shellCache = { html, fetchedAt: now };
+  return html;
+}
+
+/** The share page itself, with per-share link-preview meta injected. A static
+ * SPA serves one index.html for every route, so crawlers hitting `/v/:token`
+ * would see no OG tags at all — the web project rewrites `/v/:token` here,
+ * and this route serves the SPA shell with the share's meta block spliced in.
+ * Humans boot the SPA exactly as before; unknown tokens get the plain shell
+ * (the SPA renders its own not-found state). This is the prod counterpart of
+ * the web's dev-only Vite plugin (apps/web/plugins/share-meta.ts). */
+shareRoute.get("/:token/page", async (c) => {
+  const { webOrigin } = getServerEnv();
+  const [share, shell] = await Promise.all([
+    getShareByToken(c.req.param("token")),
+    fetchSpaShell(webOrigin),
+  ]);
+  c.header("Cache-Control", "public, max-age=300");
+  if (!share) {
+    return c.html(shell);
+  }
+  const base = `${webOrigin}/api/share/${share.token}`;
+  return c.html(
+    injectShareMeta(
+      shell,
+      buildShareMetaTags({
+        title: share.title,
+        description: SHARE_META_DESCRIPTION,
+        pageUrl: `${webOrigin}/v/${share.token}`,
+        imageUrl: `${base}/og.png`,
+        videoUrl: `${base}/video.mp4`,
+        embedUrl: `${base}/embed`,
+      })
+    )
+  );
 });
 
 /** The `twitter:player` iframe target — an inline video player crawlers can embed. */

--- a/apps/web/plugins/share-meta.ts
+++ b/apps/web/plugins/share-meta.ts
@@ -13,15 +13,17 @@
 import { readFileSync } from "node:fs";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { join } from "node:path";
-import { buildShareMetaTags, injectShareMeta } from "@animus/core";
+import {
+	buildShareMetaTags,
+	injectShareMeta,
+	SHARE_META_DESCRIPTION,
+} from "@animus/core";
 import type { Logger, Plugin, ViteDevServer } from "vite";
 
 function describe(error: unknown): string {
 	return error instanceof Error ? error.message : String(error);
 }
 
-const SHARE_DESCRIPTION =
-	"A narrated explainer, researched and animated by animus. Make your own in minutes.";
 const V_ROUTE = /^\/v\/([\w-]+)\/?$/;
 
 /** Public origin the crawler reached us on, honoring forwarded headers (behind a
@@ -92,7 +94,7 @@ async function serveInjected(
 				html,
 				buildShareMetaTags({
 					title,
-					description: SHARE_DESCRIPTION,
+					description: SHARE_META_DESCRIPTION,
 					pageUrl: `${origin}/v/${token}`,
 					imageUrl: `${base}/og.png`,
 					videoUrl: `${base}/video.mp4`,

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -5,6 +5,10 @@
 			"source": "/api/:path*",
 			"destination": "https://animus-api.vercel.app/api/:path*"
 		},
+		{
+			"source": "/v/:token",
+			"destination": "https://animus-api.vercel.app/api/share/:token/page"
+		},
 		{ "source": "/(.*)", "destination": "/index.html" }
 	]
 }

--- a/packages/core/src/share-meta.ts
+++ b/packages/core/src/share-meta.ts
@@ -14,6 +14,11 @@ import { OG_HEIGHT, OG_WIDTH } from "./share-card.ts";
 export const SHARE_META_START = "<!-- share-meta:start -->";
 export const SHARE_META_END = "<!-- share-meta:end -->";
 
+/** Default description for share link previews — one string for every
+ * injection layer (the Vite dev plugin and the API's prod page route). */
+export const SHARE_META_DESCRIPTION =
+  "A narrated explainer, researched and animated by animus. Make your own in minutes.";
+
 /** Default player embed dimensions (our videos are 16:9). */
 const PLAYER_WIDTH = 1280;
 const PLAYER_HEIGHT = 720;


### PR DESCRIPTION
Shared links (e.g. `tryanimus.app/v/<token>`) showed **no preview at all** on Discord/Twitter: in prod, `/v/:token` hit the SPA fallback and served the bare `index.html` — the meta-injection layer only existed as a Vite dev plugin, and crawlers don't run JS.

This closes the deliberately-left seam with the "API serves the page" option from the original design:

- **`GET /api/share/:token/page`** — fetches the SPA shell from `WEB_ORIGIN` (cached in-process ~5 min), splices in the per-share OG/Twitter block via the existing `@animus/core` builders (`og:image` card, `og:video` + `twitter:player` for inline playback), and serves it. Unknown tokens get the plain shell; humans boot the SPA as before.
- **`apps/web/vercel.json`** — `/v/:token` rewrites to that route, placed between the `/api` rewrite and the SPA fallback.
- `SHARE_META_DESCRIPTION` moved into core so the dev plugin and prod injector share one copy.
- CLAUDE.md: meta-injection seam marked resolved.

4 new tests (350 total): injected meta with absolute escaped URLs, plain shell for unknown tokens, 503 on shell-fetch failure, shell caching.

Note: both projects redeploy on merge (API needs the route, web needs the rewrite). Discord caches previews — verify with a cache-busting query or a fresh share.