### PR TITLE
fix: chat turns survive abort/error — persistence, metering, visibility, concurrency cap

### DIFF
--- a/apps/api/src/__tests__/chat.route.test.ts
+++ b/apps/api/src/__tests__/chat.route.test.ts
@@ -111,23 +111,39 @@ const COMPLETED: UIMessage[] = [
   { id: "a1", role: "assistant", parts: [{ type: "text", text: "hello" }] },
 ];
 
-/** A fake agent whose stream, on finish, invokes onFinish with completed
- * messages and exposes token usage — mirroring the AI SDK stream result. */
-function stubAgentStream(usage = { inputTokens: 100, outputTokens: 50 }) {
+interface StreamResponseOptions {
+  onError: (error: unknown) => string;
+  onFinish: (arg: {
+    messages: UIMessage[];
+    isAborted: boolean;
+  }) => Promise<void> | void;
+}
+
+/** Fires the onStepFinish the route registered on the agent — usage is
+ * accumulated per completed step, exactly as the SDK reports it. */
+function emitStep(usage: { inputTokens: number; outputTokens: number }) {
+  const deps = createManimAgent.mock.calls.at(-1)?.[0] as {
+    onStepFinish?: (step: { usage: typeof usage }) => void;
+  };
+  deps.onStepFinish?.({ usage });
+}
+
+/** A fake agent whose stream completes one step and finishes — mirroring the
+ * AI SDK stream result surface the route consumes. */
+function stubAgentStream(
+  usage = { inputTokens: 100, outputTokens: 50 },
+  { isAborted = false } = {}
+) {
   const toUIMessageStreamResponse = vi.fn(
-    async (opts: {
-      onFinish: (arg: { messages: UIMessage[] }) => Promise<void> | void;
-    }) => {
-      await opts.onFinish({ messages: COMPLETED });
+    async (opts: StreamResponseOptions) => {
+      emitStep(usage);
+      await opts.onFinish({ messages: COMPLETED, isAborted });
       return new Response("ok");
     }
   );
-  const stream = vi.fn().mockResolvedValue({
-    toUIMessageStreamResponse,
-    totalUsage: Promise.resolve(usage),
-  });
+  const stream = vi.fn().mockResolvedValue({ toUIMessageStreamResponse });
   createManimAgent.mockReturnValue({ stream });
-  return { stream };
+  return { stream, toUIMessageStreamResponse };
 }
 
 beforeEach(() => {
@@ -381,5 +397,130 @@ describe("POST /chat — happy path (metered)", () => {
 
     expect(res.status).toBe(200);
     expect(setConversationSandboxId).not.toHaveBeenCalled();
+  });
+
+  it("sums usage across multiple completed steps", async () => {
+    const toUIMessageStreamResponse = vi.fn(
+      async (opts: StreamResponseOptions) => {
+        emitStep({ inputTokens: 1000, outputTokens: 20 });
+        emitStep({ inputTokens: 2500, outputTokens: 80 });
+        await opts.onFinish({ messages: COMPLETED, isAborted: false });
+        return new Response("ok");
+      }
+    );
+    createManimAgent.mockReturnValue({
+      stream: vi.fn().mockResolvedValue({ toUIMessageStreamResponse }),
+    });
+
+    await post({ id: "u1" }, { id: "conv1", message: userMessage("m1", "hi") });
+
+    expect(settleUsage).toHaveBeenCalledWith(
+      expect.objectContaining({ inputTokens: 3500, outputTokens: 100 })
+    );
+  });
+});
+
+describe("POST /chat — turn lifecycle (abort/error)", () => {
+  it("persists messages and settles an ABORTED turn, without titling it", async () => {
+    stubAgentStream(
+      { inputTokens: 700, outputTokens: 30 },
+      { isAborted: true }
+    );
+
+    const res = await post(
+      { id: "u1" },
+      { id: "conv1", message: userMessage("m1", "hi") }
+    );
+
+    expect(res.status).toBe(200);
+    // The stopped turn keeps the user's message and partial assistant work.
+    expect(saveConversationMessages).toHaveBeenCalledWith({
+      conversationId: "conv1",
+      messages: COMPLETED,
+    });
+    expect(maybeGenerateConversationTitle).not.toHaveBeenCalled();
+    // Steps completed before the abort are real spend — they settle.
+    expect(settleUsage).toHaveBeenCalledWith(
+      expect.objectContaining({ inputTokens: 700, outputTokens: 30 })
+    );
+  });
+
+  it("settles on a stream error and returns a sanitized message", async () => {
+    const toUIMessageStreamResponse = vi.fn(
+      async (opts: StreamResponseOptions) => {
+        emitStep({ inputTokens: 400, outputTokens: 10 });
+        const clientText = opts.onError(
+          new Error("Bedrock exploded: sk-secret")
+        );
+        expect(clientText).not.toContain("Bedrock");
+        expect(clientText).not.toContain("sk-secret");
+        await opts.onFinish({ messages: COMPLETED, isAborted: false });
+        return new Response("ok");
+      }
+    );
+    createManimAgent.mockReturnValue({
+      stream: vi.fn().mockResolvedValue({ toUIMessageStreamResponse }),
+    });
+
+    await post({ id: "u1" }, { id: "conv1", message: userMessage("m1", "hi") });
+
+    // Settled exactly once despite both the error and finish paths running.
+    expect(settleUsage).toHaveBeenCalledTimes(1);
+    expect(settleUsage).toHaveBeenCalledWith(
+      expect.objectContaining({ inputTokens: 400, outputTokens: 10 })
+    );
+  });
+});
+
+describe("POST /chat — per-user concurrency cap", () => {
+  it("429s a third simultaneous turn and frees the slot when a turn ends", async () => {
+    // Streams that never finish: the returned response leaves onFinish
+    // uncalled, so the slot stays held.
+    const held: StreamResponseOptions[] = [];
+    const toUIMessageStreamResponse = vi.fn((opts: StreamResponseOptions) => {
+      held.push(opts);
+      return new Response("ok");
+    });
+    createManimAgent.mockReturnValue({
+      stream: vi.fn().mockResolvedValue({ toUIMessageStreamResponse }),
+    });
+
+    const user = { id: "u-cap" };
+    const msg = (id: string) => ({
+      id: "conv1",
+      message: userMessage(id, "hi"),
+    });
+
+    expect((await post(user, msg("m1"))).status).toBe(200);
+    expect((await post(user, msg("m2"))).status).toBe(200);
+    const third = await post(user, msg("m3"));
+    expect(third.status).toBe(429);
+
+    // Finish one held turn — its slot frees and the next request is admitted.
+    const first = held[0];
+    if (!first) {
+      throw new Error("expected a held stream");
+    }
+    await first.onFinish({ messages: COMPLETED, isAborted: false });
+    expect((await post(user, msg("m4"))).status).toBe(200);
+  });
+
+  it("does not leak the slot when the sandbox fails to start", async () => {
+    const user = { id: "u-sandbox-fail" };
+    ensureSandbox.mockRejectedValueOnce(new Error("daytona down"));
+
+    const failed = await post(user, {
+      id: "conv1",
+      message: userMessage("m1", "hi"),
+    });
+    expect(failed.status).toBe(500);
+
+    // The slot released on the throw — the retry is admitted, twice over.
+    ensureSandbox.mockResolvedValue({ id: "new-sandbox" });
+    stubAgentStream();
+    expect(
+      (await post(user, { id: "conv1", message: userMessage("m2", "hi") }))
+        .status
+    ).toBe(200);
   });
 });

--- a/apps/api/src/__tests__/credits.service.test.ts
+++ b/apps/api/src/__tests__/credits.service.test.ts
@@ -24,8 +24,8 @@ vi.mock("@animus/core/env", () => ({
   getServerEnv: () => ({ creditsGlobalCapUsd: h.capUsd }),
 }));
 
-vi.mock("@animus/db", () => ({
-  db: {
+vi.mock("@animus/db", () => {
+  const dbLike = {
     query: { userCredits: { findFirst: h.findFirst } },
     // A chainable, thenable select: every chain method returns the builder and
     // awaiting it resolves the next queued result (or the legacy selectRows).
@@ -62,16 +62,24 @@ vi.mock("@animus/db", () => ({
       },
     }),
     update: () => ({ set: () => ({ where: h.updateWhere }) }),
-  },
-  conversation: CONVERSATION,
-  count: vi.fn(() => ({ count: true })),
-  desc: vi.fn((column) => ({ desc: column })),
-  eq: vi.fn((left, right) => ({ eq: [left, right] })),
-  inArray: vi.fn((column, values) => ({ inArray: [column, values] })),
-  sqlExpr: vi.fn(() => ({ sql: true })),
-  userCredits: USER_CREDITS,
-  usageEvent: USAGE_EVENT,
-}));
+  };
+  return {
+    db: {
+      ...dbLike,
+      // Settlement runs inside a transaction; the callback gets the same
+      // db-like surface so inserts/updates hit the same recorders.
+      transaction: (fn: (tx: typeof dbLike) => unknown) => fn(dbLike),
+    },
+    conversation: CONVERSATION,
+    count: vi.fn(() => ({ count: true })),
+    desc: vi.fn((column) => ({ desc: column })),
+    eq: vi.fn((left, right) => ({ eq: [left, right] })),
+    inArray: vi.fn((column, values) => ({ inArray: [column, values] })),
+    sqlExpr: vi.fn(() => ({ sql: true })),
+    userCredits: USER_CREDITS,
+    usageEvent: USAGE_EVENT,
+  };
+});
 
 const { getOrCreateCredits, listUsage, settleUsage } = await import(
   "../services/credits.ts"

--- a/apps/api/src/routes/chat.ts
+++ b/apps/api/src/routes/chat.ts
@@ -1,22 +1,25 @@
 /** The streaming chat endpoint. Each request runs one turn of the agent's
  * tool-loop and streams the result back as a UI-message stream the web's
  * useChat consumes. The database is authoritative: the client sends only the
- * newest changed UI message, and the completed stream snapshot is persisted
- * once the turn finishes.
+ * newest changed UI message, and the stream snapshot is persisted when the
+ * turn finishes — including aborted and errored turns, so a stopped stream
+ * never loses the user's message or an already-rendered video.
  *
  * Cost control: a turn is metered per-component — the LLM unless the user
  * brought their own key, and TTS unless they brought an ElevenLabs key. A
- * metered turn is refused up front at a non-positive balance (402), and the
- * turn's real cost is settled against the balance on finish. */
+ * metered turn is refused up front at a non-positive balance (402), usage is
+ * accumulated per step as the loop runs, and the turn settles on finish,
+ * abort, or error alike. */
 
 import { randomUUID } from "node:crypto";
 import { createManimAgent, ensureSandbox } from "@animus/agent";
 import { OUT_OF_CREDITS } from "@animus/core";
 import { getServerEnv } from "@animus/core/env";
-import { convertToModelMessages, createIdGenerator } from "ai";
+import { consumeStream, convertToModelMessages, createIdGenerator } from "ai";
 import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
+import { logger } from "../lib/logger.ts";
 import { backgroundMusicUrl, saveVideo } from "../lib/media.ts";
 import { userId } from "../lib/user.ts";
 import { requireAuth } from "../middleware/auth.ts";
@@ -39,6 +42,39 @@ import type { AppEnv } from "../types.ts";
 export const chatRoute = new Hono<AppEnv>();
 
 chatRoute.use("*", requireAuth);
+
+/** Concurrent-turn cap per user: each turn binds a sandbox and burns metered
+ * spend, and the balance gate only checks at turn START — without a cap, a
+ * near-zero balance could fan out arbitrarily many parallel turns across
+ * conversations. In-memory is sufficient while prod runs a single container;
+ * revisit with a DB-backed lock if the API ever scales out. */
+const MAX_TURNS_PER_USER = 2;
+const inFlightTurns = new Map<string, number>();
+
+function acquireTurnSlot(uid: string): (() => void) | null {
+  const inFlight = inFlightTurns.get(uid) ?? 0;
+  if (inFlight >= MAX_TURNS_PER_USER) {
+    return null;
+  }
+  inFlightTurns.set(uid, inFlight + 1);
+  let released = false;
+  return () => {
+    if (released) {
+      return;
+    }
+    released = true;
+    const current = inFlightTurns.get(uid) ?? 1;
+    if (current <= 1) {
+      inFlightTurns.delete(uid);
+    } else {
+      inFlightTurns.set(uid, current - 1);
+    }
+  };
+}
+
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
 
 /** Request envelope: the conversation id plus the newest UI message. The
  * message's internal shape is checked separately by isUIMessage — here Zod
@@ -67,115 +103,185 @@ chatRoute.post("/", async (c) => {
     throw new HTTPException(404, { message: "Conversation not found" });
   }
 
-  // Resolve the effective keys for this turn. A component is metered only when
-  // it runs on our key (the user has not brought their own).
-  const env = getServerEnv();
-  const llmKey = await getDecryptedLlmKey(uid);
-  const ttsKey = await getDecryptedTtsKey(uid);
-  const isLlmMetered = !llmKey;
-  const isTtsMetered = !ttsKey;
-  const metered = isLlmMetered || isTtsMetered;
-  const elevenLabsApiKey = ttsKey ?? env.elevenLabsApiKey;
+  const releaseTurn = acquireTurnSlot(uid);
+  if (!releaseTurn) {
+    throw new HTTPException(429, {
+      message:
+        "You already have videos generating. Wait for one to finish before starting another.",
+    });
+  }
 
-  const messages = mergeIncomingMessage(found.messages, body.message);
+  try {
+    // Resolve the effective keys for this turn. A component is metered only
+    // when it runs on our key (the user has not brought their own).
+    const env = getServerEnv();
+    const llmKey = await getDecryptedLlmKey(uid);
+    const ttsKey = await getDecryptedTtsKey(uid);
+    const isLlmMetered = !llmKey;
+    const isTtsMetered = !ttsKey;
+    const metered = isLlmMetered || isTtsMetered;
+    const elevenLabsApiKey = ttsKey ?? env.elevenLabsApiKey;
 
-  // Pre-flight gate: a metered turn needs a positive balance to start. The
-  // running turn is never killed, so the balance may end slightly negative.
-  if (metered) {
-    const { balanceMicros } = await getOrCreateCredits(uid);
-    if (balanceMicros <= 0) {
-      // Persist the refused message: the client only ever sends the newest
-      // one, so without this save it would silently vanish from the thread
-      // once the user tops up and sends the next message.
-      await saveConversationMessages({ conversationId, messages });
-      // Name the key that actually unblocks them — a user who already brought
-      // an LLM key is metered only for narration, and vice versa.
-      let missingKeys = "model and ElevenLabs keys";
-      if (!isTtsMetered) {
-        missingKeys = "model key";
-      } else if (!isLlmMetered) {
-        missingKeys = "ElevenLabs narration key";
+    const messages = mergeIncomingMessage(found.messages, body.message);
+
+    // Pre-flight gate: a metered turn needs a positive balance to start. The
+    // running turn is never killed, so the balance may end slightly negative.
+    if (metered) {
+      const { balanceMicros } = await getOrCreateCredits(uid);
+      if (balanceMicros <= 0) {
+        // Persist the refused message: the client only ever sends the newest
+        // one, so without this save it would silently vanish from the thread
+        // once the user tops up and sends the next message.
+        await saveConversationMessages({ conversationId, messages });
+        releaseTurn();
+        // Name the key that actually unblocks them — a user who already
+        // brought an LLM key is metered only for narration, and vice versa.
+        let missingKeys = "model and ElevenLabs keys";
+        if (!isTtsMetered) {
+          missingKeys = "model key";
+        } else if (!isLlmMetered) {
+          missingKeys = "ElevenLabs narration key";
+        }
+        return c.json(
+          {
+            code: OUT_OF_CREDITS,
+            message: `You're out of credits. Add your own ${missingKeys} in settings to keep going.`,
+          },
+          402
+        );
       }
-      return c.json(
-        {
-          code: OUT_OF_CREDITS,
-          message: `You're out of credits. Add your own ${missingKeys} in settings to keep going.`,
-        },
-        402
-      );
     }
-  }
 
-  // Create-or-resume this conversation's sandbox and bind the Manim tools to it.
-  // First creation bootstraps the toolchain and can take a few minutes.
-  const sandbox = await ensureSandbox({
-    conversationId,
-    sandboxId: found.conversation.sandboxId,
-    elevenLabsApiKey,
-  });
-  if (sandbox.id !== found.conversation.sandboxId) {
-    await setConversationSandboxId(conversationId, sandbox.id);
-  }
+    // Create-or-resume this conversation's sandbox and bind the Manim tools to
+    // it. First creation bootstraps the toolchain and can take a few minutes.
+    const sandbox = await ensureSandbox({
+      conversationId,
+      sandboxId: found.conversation.sandboxId,
+      elevenLabsApiKey,
+    });
+    if (sandbox.id !== found.conversation.sandboxId) {
+      await setConversationSandboxId(conversationId, sandbox.id);
+    }
 
-  // Accumulates narration characters synthesized this turn, for TTS metering.
-  const meter = { ttsChars: 0 };
+    // Accumulates narration characters synthesized this turn, for TTS metering.
+    const meter = { ttsChars: 0 };
 
-  // Idempotency key for settling this turn's cost. Must be unique PER REQUEST,
-  // not per assistant message: a single assistant message spans multiple
-  // requests during a human-in-the-loop tool exchange (the user answers, the
-  // same message continues), so keying on the message id would dedupe — and
-  // never charge — every continuation after the first.
-  const turnId = randomUUID();
+    // LLM usage accumulated per completed step. `totalUsage` reports nothing
+    // for an aborted stream — and the most expensive turns (long renders cut
+    // by the platform's duration cap, the user pressing Stop) are exactly the
+    // aborted ones, so metering must not depend on a clean finish.
+    const usageTotals = { inputTokens: 0, outputTokens: 0 };
 
-  const agent = createManimAgent({
-    sandbox,
-    conversationId,
-    saveVideo,
-    backgroundMusicUrl,
-    elevenLabsApiKey,
-    meter,
-    llmKey,
-    telemetry: aiTelemetry({
-      functionId: "manim-agent",
-      metadata: {
-        conversationId,
-        userId: uid,
-        model: llmKey ? llmKey.model : env.bedrockModel,
+    // Idempotency key for settling this turn's cost. Must be unique PER
+    // REQUEST, not per assistant message: a single assistant message spans
+    // multiple requests during a human-in-the-loop tool exchange (the user
+    // answers, the same message continues), so keying on the message id would
+    // dedupe — and never charge — every continuation after the first.
+    const turnId = randomUUID();
+
+    // Settle exactly once per turn, whichever path ends it (finish, abort, or
+    // error). settleUsage is also idempotent on turnId server-side.
+    let settled = false;
+    const settleTurn = async () => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      try {
+        await settleUsage({
+          userId: uid,
+          conversationId,
+          turnId,
+          isLlmMetered,
+          model: env.bedrockModel,
+          inputTokens: usageTotals.inputTokens,
+          outputTokens: usageTotals.outputTokens,
+          isTtsMetered,
+          ttsChars: meter.ttsChars,
+        });
+      } catch (error) {
+        logger.error(
+          { conversationId, turnId, error: describeError(error) },
+          "failed to settle turn usage"
+        );
+      }
+    };
+
+    const agent = createManimAgent({
+      sandbox,
+      conversationId,
+      saveVideo,
+      backgroundMusicUrl,
+      elevenLabsApiKey,
+      meter,
+      llmKey,
+      onStepFinish: (step) => {
+        usageTotals.inputTokens += step.usage.inputTokens ?? 0;
+        usageTotals.outputTokens += step.usage.outputTokens ?? 0;
       },
-    }),
-  });
-  const result = await agent.stream({
-    abortSignal: c.req.raw.signal,
-    prompt: await convertToModelMessages(messages),
-  });
+      telemetry: aiTelemetry({
+        functionId: "manim-agent",
+        metadata: {
+          conversationId,
+          userId: uid,
+          model: llmKey ? llmKey.model : env.bedrockModel,
+        },
+      }),
+    });
+    const result = await agent.stream({
+      abortSignal: c.req.raw.signal,
+      prompt: await convertToModelMessages(messages),
+    });
 
-  return result.toUIMessageStreamResponse({
-    generateMessageId: createIdGenerator({ prefix: "msg", size: 16 }),
-    originalMessages: messages,
-    onFinish: async ({ messages: completedMessages }) => {
-      await saveConversationMessages({
-        conversationId,
-        messages: completedMessages,
-      });
-      maybeGenerateConversationTitle({
-        conversationId,
-        messages: completedMessages,
-      });
-
-      // Settle this turn's metered cost against the balance, keyed by the
-      // per-request turn id (idempotent if this same request settles twice).
-      const usage = await result.totalUsage;
-      await settleUsage({
-        userId: uid,
-        conversationId,
-        turnId,
-        isLlmMetered,
-        model: env.bedrockModel,
-        inputTokens: usage.inputTokens ?? 0,
-        outputTokens: usage.outputTokens ?? 0,
-        isTtsMetered,
-        ttsChars: meter.ttsChars,
-      });
-    },
-  });
+    return result.toUIMessageStreamResponse({
+      generateMessageId: createIdGenerator({ prefix: "msg", size: 16 }),
+      originalMessages: messages,
+      // Keep consuming the stream server-side so a client disconnect (closed
+      // tab, dropped network) doesn't halt persistence and settlement mid-turn.
+      // Also the turn's backstop: when the SSE stream ends — however it ends —
+      // settle and release the slot even if onFinish never fired.
+      consumeSseStream: ({ stream }) => {
+        consumeStream({ stream }).finally(() => {
+          settleTurn().finally(releaseTurn);
+        });
+      },
+      // Surfaced to the client as the error part's text; the raw error stays
+      // in the logs. Settlement still runs — steps completed before the error
+      // were real spend.
+      onError: (error) => {
+        logger.error(
+          { conversationId, turnId, error: describeError(error) },
+          "chat stream errored mid-turn"
+        );
+        settleTurn().catch(() => {
+          // settleTurn logs its own failures.
+        });
+        return "Something went wrong while generating. Try sending your message again.";
+      },
+      onFinish: async ({ messages: completedMessages, isAborted }) => {
+        try {
+          // Persist whatever the turn produced — a stopped or cut turn keeps
+          // the user's message and any partial assistant work (including a
+          // rendered video's key, which would otherwise orphan in R2).
+          await saveConversationMessages({
+            conversationId,
+            messages: completedMessages,
+          });
+          if (!isAborted) {
+            maybeGenerateConversationTitle({
+              conversationId,
+              messages: completedMessages,
+            });
+          }
+        } finally {
+          await settleTurn();
+          releaseTurn();
+        }
+      },
+    });
+  } catch (error) {
+    // The turn never produced a stream; without this the slot would leak.
+    releaseTurn();
+    throw error;
+  }
 });

--- a/apps/api/src/services/credits.ts
+++ b/apps/api/src/services/credits.ts
@@ -108,37 +108,41 @@ export async function settleUsage(input: SettleUsageInput): Promise<number> {
     return 0;
   }
 
-  // Record the turn first; the unique turn_id makes this the idempotency guard —
-  // if the row already exists, the debit below is skipped.
-  const inserted = await db
-    .insert(usageEvent)
-    .values({
-      id: randomUUID(),
-      userId: input.userId,
-      conversationId: input.conversationId,
-      turnId: input.turnId,
-      model: input.isLlmMetered ? input.model : null,
-      inputTokens: input.inputTokens,
-      outputTokens: input.outputTokens,
-      ttsChars: input.ttsChars,
-      costMicros,
-    })
-    .onConflictDoNothing({ target: usageEvent.turnId })
-    .returning({ id: usageEvent.id });
+  // One transaction: the ledger insert (whose unique turn_id is the
+  // idempotency guard — an existing row skips the debit) and the balance
+  // debit commit or roll back together. Split statements once left a ledger
+  // row without its debit on a crash, permanently blocking the retry.
+  return await db.transaction(async (tx) => {
+    const inserted = await tx
+      .insert(usageEvent)
+      .values({
+        id: randomUUID(),
+        userId: input.userId,
+        conversationId: input.conversationId,
+        turnId: input.turnId,
+        model: input.isLlmMetered ? input.model : null,
+        inputTokens: input.inputTokens,
+        outputTokens: input.outputTokens,
+        ttsChars: input.ttsChars,
+        costMicros,
+      })
+      .onConflictDoNothing({ target: usageEvent.turnId })
+      .returning({ id: usageEvent.id });
 
-  if (inserted.length === 0) {
-    return 0;
-  }
+    if (inserted.length === 0) {
+      return 0;
+    }
 
-  await db
-    .update(userCredits)
-    .set({
-      balanceMicros: sqlExpr`${userCredits.balanceMicros} - ${costMicros}`,
-      updatedAt: new Date(),
-    })
-    .where(eq(userCredits.userId, input.userId));
+    await tx
+      .update(userCredits)
+      .set({
+        balanceMicros: sqlExpr`${userCredits.balanceMicros} - ${costMicros}`,
+        updatedAt: new Date(),
+      })
+      .where(eq(userCredits.userId, input.userId));
 
-  return costMicros;
+    return costMicros;
+  });
 }
 
 export interface ListUsageInput {

--- a/apps/web/src/features/studio/components/chat-panel.tsx
+++ b/apps/web/src/features/studio/components/chat-panel.tsx
@@ -1,10 +1,12 @@
 import type { ChatStatus } from "ai";
+import { RotateCcwIcon } from "lucide-react";
 import {
 	Conversation,
 	ConversationContent,
 	ConversationScrollButton,
 } from "@/components/ai-elements/conversation";
 import { Shimmer } from "@/components/ai-elements/shimmer";
+import { Button } from "@/components/ui/button";
 import { ChatMessage } from "@/features/studio/components/chat-message";
 import { StudioPrompt } from "@/features/studio/components/studio-prompt";
 import type { AnimusUIMessage, RespondToTool } from "@/features/studio/types";
@@ -16,6 +18,8 @@ export function ChatPanel({
 	onSubmit,
 	onStop,
 	onOpenVideo,
+	error,
+	onRetry,
 }: {
 	messages: AnimusUIMessage[];
 	status: ChatStatus;
@@ -23,6 +27,8 @@ export function ChatPanel({
 	onSubmit: (text: string) => void;
 	onStop: () => void;
 	onOpenVideo?: (key: string) => void;
+	error?: Error;
+	onRetry?: () => void;
 }) {
 	const lastIndex = messages.length - 1;
 	return (
@@ -44,6 +50,20 @@ export function ChatPanel({
 					))}
 					{status === "submitted" ? (
 						<Shimmer>Thinking through the explanation…</Shimmer>
+					) : null}
+					{status === "error" ? (
+						<div className="flex items-center justify-between gap-3 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm">
+							<span className="text-destructive">
+								{error?.message ||
+									"Something went wrong while generating. Try again."}
+							</span>
+							{onRetry ? (
+								<Button onClick={onRetry} size="sm" variant="outline">
+									<RotateCcwIcon data-icon="inline-start" />
+									Retry
+								</Button>
+							) : null}
+						</div>
 					) : null}
 				</ConversationContent>
 				<ConversationScrollButton />

--- a/apps/web/src/features/studio/components/studio-view.tsx
+++ b/apps/web/src/features/studio/components/studio-view.tsx
@@ -44,6 +44,8 @@ export function StudioStage({
 	respondToTool,
 	onSubmit,
 	onStop,
+	error,
+	onRetry,
 }: {
 	phase: StudioPhase;
 	messages: AnimusUIMessage[];
@@ -54,6 +56,8 @@ export function StudioStage({
 	respondToTool: RespondToTool;
 	onSubmit: (text: string) => void;
 	onStop: () => void;
+	error?: Error;
+	onRetry?: () => void;
 }) {
 	useRenderNotification(videoKey);
 
@@ -65,7 +69,9 @@ export function StudioStage({
 			{phase === "loading" ? <StudioLoading /> : null}
 			{phase === "chat" ? (
 				<StudioWorkspace
+					error={error}
 					messages={messages}
+					onRetry={onRetry}
 					onStop={onStop}
 					onSubmit={onSubmit}
 					respondToTool={respondToTool}

--- a/apps/web/src/features/studio/components/studio-workspace.tsx
+++ b/apps/web/src/features/studio/components/studio-workspace.tsx
@@ -23,6 +23,8 @@ export function StudioWorkspace({
 	respondToTool,
 	onSubmit,
 	onStop,
+	error,
+	onRetry,
 }: {
 	messages: AnimusUIMessage[];
 	status: ChatStatus;
@@ -32,6 +34,8 @@ export function StudioWorkspace({
 	respondToTool: RespondToTool;
 	onSubmit: (text: string) => void;
 	onStop: () => void;
+	error?: Error;
+	onRetry?: () => void;
 }) {
 	const isMobile = useIsMobile();
 	const videoPanelRef = useRef<PanelImperativeHandle>(null);
@@ -77,8 +81,10 @@ export function StudioWorkspace({
 
 	const chatPanel = (
 		<ChatPanel
+			error={error}
 			messages={messages}
 			onOpenVideo={openVideo}
+			onRetry={onRetry}
 			onStop={onStop}
 			onSubmit={onSubmit}
 			respondToTool={respondToTool}

--- a/apps/web/src/features/studio/hooks/use-studio-chat.ts
+++ b/apps/web/src/features/studio/hooks/use-studio-chat.ts
@@ -23,6 +23,10 @@ type StudioChat = {
 	send: (text: string) => void;
 	stop: () => void;
 	respondToTool: RespondToTool;
+	/** The error that ended the last turn, if it ended in one. */
+	error?: Error;
+	/** Re-runs the failed turn (regenerates from the last user message). */
+	retry: () => void;
 };
 
 /** The studio's chat session over the streaming /api/chat endpoint. Keyed by
@@ -40,18 +44,25 @@ export function useStudioChat({
 	initialMessages?: AnimusUIMessage[];
 	onConversationUpdated?: () => void;
 }): StudioChat {
-	const { messages, sendMessage, status, addToolOutput, stop } =
-		useChat<AnimusUIMessage>({
-			id: chatId,
-			messages: initialMessages,
-			transport: chatTransport,
-			sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
-			onFinish: () => {
-				onConversationUpdated?.();
-				// A completed turn may have drawn down the balance — refresh the gauge.
-				notifyCreditsChanged();
-			},
-		});
+	const {
+		messages,
+		sendMessage,
+		status,
+		addToolOutput,
+		stop,
+		error,
+		regenerate,
+	} = useChat<AnimusUIMessage>({
+		id: chatId,
+		messages: initialMessages,
+		transport: chatTransport,
+		sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
+		onFinish: () => {
+			onConversationUpdated?.();
+			// A completed turn may have drawn down the balance — refresh the gauge.
+			notifyCreditsChanged();
+		},
+	});
 
 	// Auto-run the first prompt exactly once for a genuinely new conversation.
 	// Capture whether the loaded snapshot already had messages at mount: router
@@ -119,5 +130,19 @@ export function useStudioChat({
 		}
 	}
 
-	return { messages, status, phase, videoKey, send, stop, respondToTool };
+	const retry = useCallback(() => {
+		void regenerate();
+	}, [regenerate]);
+
+	return {
+		messages,
+		status,
+		phase,
+		videoKey,
+		send,
+		stop,
+		respondToTool,
+		error,
+		retry,
+	};
 }

--- a/apps/web/src/pages/studio-page.tsx
+++ b/apps/web/src/pages/studio-page.tsx
@@ -52,15 +52,24 @@ function LoadedStudioChat({
 }) {
 	const location = useLocation();
 	const prompt = (location.state as { prompt?: string } | null)?.prompt;
-	const { messages, status, phase, videoKey, respondToTool, send, stop } =
-		useStudioChat({
-			chatId,
-			initialPrompt: prompt,
-			initialMessages: detail.messages as AnimusUIMessage[],
-			// A finished turn persists new messages and may generate a title; let
-			// the sidebar and detail hook refresh from that single signal.
-			onConversationUpdated: notifyConversationsChanged,
-		});
+	const {
+		messages,
+		status,
+		phase,
+		videoKey,
+		respondToTool,
+		send,
+		stop,
+		error: turnError,
+		retry,
+	} = useStudioChat({
+		chatId,
+		initialPrompt: prompt,
+		initialMessages: detail.messages as AnimusUIMessage[],
+		// A finished turn persists new messages and may generate a title; let
+		// the sidebar and detail hook refresh from that single signal.
+		onConversationUpdated: notifyConversationsChanged,
+	});
 
 	// Expose the latest render to the header's Publish menu (disabled until one exists).
 	useRegisterPublishTarget(
@@ -69,7 +78,9 @@ function LoadedStudioChat({
 
 	return (
 		<StudioStage
+			error={turnError}
 			messages={messages}
+			onRetry={retry}
 			onStop={stop}
 			onSubmit={send}
 			phase={phase}

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -3,7 +3,12 @@
  * research always, plus the Manim sandbox tools bound to this conversation. */
 
 import type { Sandbox } from "@daytonaio/sdk";
-import { type TelemetrySettings, ToolLoopAgent, type ToolSet } from "ai";
+import {
+  type TelemetrySettings,
+  ToolLoopAgent,
+  type ToolLoopAgentOnStepFinishCallback,
+  type ToolSet,
+} from "ai";
 import { type LlmKey, resolveModel } from "./config/index.ts";
 import { MANIM_SYSTEM_PROMPT } from "./prompts/index.ts";
 import { createTools } from "./tools/index.ts";
@@ -27,6 +32,10 @@ export function createManimAgent(deps: {
   llmKey?: LlmKey;
   /** Per-turn observability; the caller (apps/api) owns policy. Omitted means no tracing. */
   telemetry?: TelemetrySettings;
+  /** Fires after every completed LLM step. The caller uses it to accumulate
+   * token usage as it happens — `totalUsage` is empty on an aborted stream,
+   * and the most expensive turns are exactly the ones that get cut. */
+  onStepFinish?: ToolLoopAgentOnStepFinishCallback<ToolSet>;
 }): ToolLoopAgent<never, ToolSet, never> {
   return new ToolLoopAgent({
     model: resolveModel(deps.llmKey).model,
@@ -45,6 +54,7 @@ export function createManimAgent(deps: {
         meter: deps.meter,
       },
     }),
+    onStepFinish: deps.onStepFinish,
     experimental_telemetry: deps.telemetry,
   });
 }


### PR DESCRIPTION
PR 2 of the stack (base: `fix/settings-nullable`, merge that first).

Everything in the turn lifecycle hung off a clean `onFinish`; aborted (Stop button, closed tab, the platform's 300s duration cap) and errored turns fell through every layer:

- **Persistence** — nothing was saved: the user's own message vanished on refresh and an already-rendered video's key orphaned in R2. Now the stream response persists on finish AND abort (`isAborted` skips only title generation), and `consumeSseStream` keeps the server consuming after a client disconnect so persistence/settlement don't die with the tab.
- **Metering** — `totalUsage` is empty on abort, so the longest, most expensive turns billed $0 (and with 0 completed steps the promise rejects, skipping TTS settlement too). Usage now accumulates per completed step via the agent's `onStepFinish`, and settles exactly once whichever way the turn ends (finish/abort/error — idempotent client-side flag + server-side turnId). The `usage_event` insert + balance debit now run in **one transaction** — a crash between them used to leave a ledger row that permanently blocked the debit retry.
- **Visibility** — a mid-turn stream death was invisible: the API now logs the real error and returns a sanitized client message; the studio destructures `error`/`regenerate` from `useChat` and renders an error row with a **Retry** button.
- **Concurrency cap** — 2 in-flight turns per user (429 above it, slot freed on every exit path incl. sandbox-start failure, with a consume-stream backstop). The balance gate only checks at turn *start*, so parallel turns from a near-zero balance were unbounded overdraft. In-memory: prod runs one container; comment marks the DB-lock upgrade path for scale-out.

7 new tests (357 total): per-step usage summing, abort persistence + settlement without titling, error-path settlement + sanitized message, 429 + slot release on finish, no slot leak on sandbox failure.