### PR TITLE
feat: generation settings actually shape the video (voice, music toggle, track)

### DIFF
--- a/apps/api/src/__tests__/chat.route.test.ts
+++ b/apps/api/src/__tests__/chat.route.test.ts
@@ -14,6 +14,7 @@ const {
   setConversationSandboxId,
   getDecryptedLlmKey,
   getDecryptedTtsKey,
+  getGenerationSettings,
   getOrCreateCredits,
   settleUsage,
 } = vi.hoisted(() => ({
@@ -27,6 +28,7 @@ const {
   setConversationSandboxId: vi.fn(),
   getDecryptedLlmKey: vi.fn(),
   getDecryptedTtsKey: vi.fn(),
+  getGenerationSettings: vi.fn(),
   getOrCreateCredits: vi.fn(),
   settleUsage: vi.fn(),
 }));
@@ -49,6 +51,7 @@ vi.mock("../services/credits.ts", () => ({ getOrCreateCredits, settleUsage }));
 vi.mock("../services/settings.ts", () => ({
   getDecryptedLlmKey,
   getDecryptedTtsKey,
+  getGenerationSettings,
 }));
 // Keep the pure helpers (isUIMessage, mergeIncomingMessage) faithful so the
 // route's validation and merge behavior is exercised for real; mock only IO.
@@ -151,6 +154,13 @@ beforeEach(() => {
   // Defaults: a metered user (no BYOK keys) with a healthy balance.
   getDecryptedLlmKey.mockResolvedValue(undefined);
   getDecryptedTtsKey.mockResolvedValue(undefined);
+  getGenerationSettings.mockResolvedValue({
+    videoTheme: "dark",
+    backgroundMusic: false,
+    musicTrack: "upbeat",
+    voiceId: "voice-user-choice",
+    font: "geist",
+  });
   getOrCreateCredits.mockResolvedValue({
     balanceMicros: FREE_GRANT_MICROS,
     grantMicros: FREE_GRANT_MICROS,
@@ -351,6 +361,10 @@ describe("POST /chat — happy path (metered)", () => {
         elevenLabsApiKey: "our-eleven-key",
         llmKey: undefined,
         meter: expect.objectContaining({ ttsChars: expect.any(Number) }),
+        // The user's generation settings shape the turn.
+        voiceId: "voice-user-choice",
+        backgroundMusic: false,
+        musicTrackId: "upbeat",
       })
     );
 

--- a/apps/api/src/__tests__/media.lib.test.ts
+++ b/apps/api/src/__tests__/media.lib.test.ts
@@ -97,15 +97,26 @@ describe("mediaKeyConversationId", () => {
 });
 
 describe("backgroundMusicUrl", () => {
-  it("presigns a GET for the fixed background music key", async () => {
+  it("presigns a GET for the catalog track's key", async () => {
     getSignedUrl.mockResolvedValue("https://signed/music");
 
-    const url = await backgroundMusicUrl();
+    const url = await backgroundMusicUrl("ambient");
 
     expect(url).toBe("https://signed/music");
     const command = getSignedUrl.mock.calls[0]?.[1];
     expect(command.input).toMatchObject({
       Bucket: "animus-videos",
+      Key: "music/The_Merchants_Of_Death.mp3",
+    });
+  });
+
+  it("falls back to the default key for an unknown track id", async () => {
+    getSignedUrl.mockResolvedValue("https://signed/music");
+
+    await backgroundMusicUrl("no-such-track");
+
+    const command = getSignedUrl.mock.calls[0]?.[1];
+    expect(command.input).toMatchObject({
       Key: "music/The_Merchants_Of_Death.mp3",
     });
   });

--- a/apps/api/src/lib/media.ts
+++ b/apps/api/src/lib/media.ts
@@ -22,8 +22,15 @@ const UNSAFE_NAME_CHARS = /[^a-zA-Z0-9_-]/g;
 const MEDIA_PREFIX = "videos";
 /** videos/<conversationId>/<file>.mp4 — pins the shape we mint and accept. */
 const MEDIA_KEY = /^videos\/([a-zA-Z0-9_-]+)\/[a-zA-Z0-9_-]+\.mp4$/;
-/** Background track muxed under every render. Fixed for now; user-configurable later. */
-const MUSIC_KEY = "music/The_Merchants_Of_Death.mp3";
+/** R2 keys for the music catalog the settings picker offers. Every id
+ * currently resolves to the one licensed track in the bucket — swap entries
+ * here as the curated library lands (ids mirror the web's MUSIC_TRACKS). */
+const FALLBACK_MUSIC_KEY = "music/The_Merchants_Of_Death.mp3";
+const MUSIC_TRACK_KEYS: Record<string, string> = {
+  ambient: FALLBACK_MUSIC_KEY,
+  upbeat: FALLBACK_MUSIC_KEY,
+  cinematic: FALLBACK_MUSIC_KEY,
+};
 
 let client: S3Client | null = null;
 
@@ -82,8 +89,8 @@ export async function saveVideo(input: {
 /** Presigned GET URL for the background track, so the sandbox downloads it
  * straight from R2 (no round-trip through the API). If absent, renderScene just
  * delivers a silent video. */
-export function backgroundMusicUrl(): Promise<string> {
-  return signMediaUrl(MUSIC_KEY);
+export function backgroundMusicUrl(trackId: string): Promise<string> {
+  return signMediaUrl(MUSIC_TRACK_KEYS[trackId] ?? FALLBACK_MUSIC_KEY);
 }
 
 /** Mint a short-lived presigned GET URL the browser can stream from directly. */

--- a/apps/api/src/routes/chat.ts
+++ b/apps/api/src/routes/chat.ts
@@ -13,7 +13,7 @@
 
 import { randomUUID } from "node:crypto";
 import { createManimAgent, ensureSandbox } from "@animus/agent";
-import { OUT_OF_CREDITS } from "@animus/core";
+import { GENERATION_DEFAULTS, OUT_OF_CREDITS } from "@animus/core";
 import { getServerEnv } from "@animus/core/env";
 import { consumeStream, convertToModelMessages, createIdGenerator } from "ai";
 import { Hono } from "hono";
@@ -36,6 +36,7 @@ import { getOrCreateCredits, settleUsage } from "../services/credits.ts";
 import {
   getDecryptedLlmKey,
   getDecryptedTtsKey,
+  getGenerationSettings,
 } from "../services/settings.ts";
 import type { AppEnv } from "../types.ts";
 
@@ -121,6 +122,10 @@ chatRoute.post("/", async (c) => {
     const isTtsMetered = !ttsKey;
     const metered = isLlmMetered || isTtsMetered;
     const elevenLabsApiKey = ttsKey ?? env.elevenLabsApiKey;
+
+    // The user's generation settings shape this turn's narration voice and
+    // music bed; a user who never saved any gets the domain defaults.
+    const settings = (await getGenerationSettings(uid)) ?? GENERATION_DEFAULTS;
 
     const messages = mergeIncomingMessage(found.messages, body.message);
 
@@ -213,6 +218,9 @@ chatRoute.post("/", async (c) => {
       saveVideo,
       backgroundMusicUrl,
       elevenLabsApiKey,
+      voiceId: settings.voiceId,
+      backgroundMusic: settings.backgroundMusic,
+      musicTrackId: settings.musicTrack,
       meter,
       llmKey,
       onStepFinish: (step) => {

--- a/packages/agent/src/__tests__/agent.test.ts
+++ b/packages/agent/src/__tests__/agent.test.ts
@@ -58,6 +58,9 @@ function build(
     saveVideo: vi.fn(() => Promise.resolve("videos/conv/x.mp4")),
     backgroundMusicUrl: vi.fn(() => Promise.resolve("https://music.test")),
     elevenLabsApiKey: "el-test-key",
+    voiceId: "voice-agent-test",
+    backgroundMusic: true,
+    musicTrackId: "ambient",
     meter: { ttsChars: 0 },
     telemetry,
     llmKey,
@@ -71,6 +74,10 @@ describe("createManimAgent", () => {
     expect(captured.config?.model).toBe("model-sentinel");
     expect(typeof captured.config?.instructions).toBe("string");
     expect(captured.config?.instructions.length).toBeGreaterThan(0);
+    // The user's settings voice is threaded into the narration instruction.
+    expect(captured.config?.instructions).toContain(
+      'voice_id="voice-agent-test"'
+    );
   });
 
   it("raises the retry budget so provider throttling waits instead of dying", () => {

--- a/packages/agent/src/__tests__/manim-tools.test.ts
+++ b/packages/agent/src/__tests__/manim-tools.test.ts
@@ -60,6 +60,8 @@ function editTool(initial: Record<string, string>) {
     conversationId: "conv-1",
     saveVideo: vi.fn(() => Promise.resolve("https://example.com/v.mp4")),
     backgroundMusicUrl: vi.fn(() => Promise.resolve("https://music.test")),
+    backgroundMusic: true,
+    musicTrackId: "ambient",
     elevenLabsApiKey: "el-test-key",
     meter: { ttsChars: 0 },
   });
@@ -77,6 +79,8 @@ function runTool(commandOut: string) {
     conversationId: "conv-1",
     saveVideo: vi.fn(() => Promise.resolve("https://example.com/v.mp4")),
     backgroundMusicUrl: vi.fn(() => Promise.resolve("https://music.test")),
+    backgroundMusic: true,
+    musicTrackId: "ambient",
     elevenLabsApiKey: "el-test-key",
     meter: { ttsChars: 0 },
   });
@@ -221,6 +225,7 @@ function renderSandbox(opts: {
   renderExit?: number;
   muxExit?: number;
   sceneSource?: string;
+  backgroundMusic?: boolean;
 }) {
   const downloadCalls: string[] = [];
   const meter = { ttsChars: 0 };
@@ -259,6 +264,8 @@ function renderSandbox(opts: {
     conversationId: "conv",
     saveVideo,
     backgroundMusicUrl,
+    backgroundMusic: opts.backgroundMusic ?? true,
+    musicTrackId: "cinematic",
     elevenLabsApiKey: "el-test-key",
     meter,
   });
@@ -271,6 +278,7 @@ function renderSandbox(opts: {
     downloadCalls,
     saveVideo,
     executeCommand,
+    backgroundMusicUrl,
     meter,
   };
 }
@@ -317,6 +325,34 @@ describe("renderScene background music", () => {
     expect(output.logs).toMatch(MUSIC_SKIPPED);
     // Scene source read for metering, then the silent master (never the failed
     // muxed file).
+    expect(downloadCalls).toEqual([SCENE_PATH, MASTER]);
+    expect(saveVideo).toHaveBeenCalledTimes(1);
+  });
+
+  it("presigns the user's chosen track id", async () => {
+    const { execute, backgroundMusicUrl } = renderSandbox({});
+
+    await execute(RENDER_INPUT, EXEC_CTX);
+
+    expect(backgroundMusicUrl).toHaveBeenCalledWith("cinematic");
+  });
+
+  it("skips the music step entirely when background music is off", async () => {
+    const {
+      execute,
+      downloadCalls,
+      saveVideo,
+      executeCommand,
+      backgroundMusicUrl,
+    } = renderSandbox({ backgroundMusic: false });
+
+    const output = await execute(RENDER_INPUT, EXEC_CTX);
+
+    expect(output.ok).toBe(true);
+    // Only the render command ran — no download/ffmpeg step, no presign.
+    expect(executeCommand).toHaveBeenCalledTimes(1);
+    expect(backgroundMusicUrl).not.toHaveBeenCalled();
+    // The silent master is what gets delivered.
     expect(downloadCalls).toEqual([SCENE_PATH, MASTER]);
     expect(saveVideo).toHaveBeenCalledTimes(1);
   });

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -10,7 +10,7 @@ import {
   type ToolSet,
 } from "ai";
 import { type LlmKey, resolveModel } from "./config/index.ts";
-import { MANIM_SYSTEM_PROMPT } from "./prompts/index.ts";
+import { buildManimSystemPrompt } from "./prompts/index.ts";
 import { createTools } from "./tools/index.ts";
 import type {
   BackgroundMusicUrl,
@@ -25,6 +25,11 @@ export function createManimAgent(deps: {
   backgroundMusicUrl: BackgroundMusicUrl;
   /** The effective ElevenLabs key for this turn (the user's own, or ours). */
   elevenLabsApiKey: string;
+  /** The user's generation settings for this turn: narration voice, and
+   * whether/which music bed to mix under the render. */
+  voiceId: string;
+  backgroundMusic: boolean;
+  musicTrackId: string;
   /** Per-turn TTS accumulator the caller reads after the turn to meter cost. */
   meter: TurnMeter;
   /** When present, the turn runs on the user's own LLM key (not metered);
@@ -43,13 +48,15 @@ export function createManimAgent(deps: {
     // calls into a turn). The default 2 retries gives up mid-loop and the turn
     // stalls; 6 retries of exponential backoff rides out the rate window.
     maxRetries: 6,
-    instructions: MANIM_SYSTEM_PROMPT,
+    instructions: buildManimSystemPrompt({ voiceId: deps.voiceId }),
     tools: createTools({
       manim: {
         sandbox: deps.sandbox,
         conversationId: deps.conversationId,
         saveVideo: deps.saveVideo,
         backgroundMusicUrl: deps.backgroundMusicUrl,
+        backgroundMusic: deps.backgroundMusic,
+        musicTrackId: deps.musicTrackId,
         elevenLabsApiKey: deps.elevenLabsApiKey,
         meter: deps.meter,
       },

--- a/packages/agent/src/prompts/__tests__/prompts.test.ts
+++ b/packages/agent/src/prompts/__tests__/prompts.test.ts
@@ -1,21 +1,29 @@
 import { describe, expect, it } from "vitest";
 import { CRAFT_LESSONS } from "../craft-lessons.ts";
-import { MANIM_SYSTEM_PROMPT } from "../index.ts";
+import { buildManimSystemPrompt } from "../index.ts";
 import { MANIM_CRAFT } from "../manim-craft.ts";
 
-describe("MANIM_SYSTEM_PROMPT", () => {
+const PROMPT = buildManimSystemPrompt({ voiceId: "voice-test-1" });
+
+describe("buildManimSystemPrompt", () => {
   it("embeds both the mechanical craft rules and the distilled craft lessons", () => {
-    expect(MANIM_SYSTEM_PROMPT).toContain(MANIM_CRAFT);
-    expect(MANIM_SYSTEM_PROMPT).toContain(CRAFT_LESSONS);
+    expect(PROMPT).toContain(MANIM_CRAFT);
+    expect(PROMPT).toContain(CRAFT_LESSONS);
   });
 
   it("orders the lessons after the mechanical craft and before 'How you work'", () => {
-    const craftAt = MANIM_SYSTEM_PROMPT.indexOf(MANIM_CRAFT);
-    const lessonsAt = MANIM_SYSTEM_PROMPT.indexOf(CRAFT_LESSONS);
-    const howYouWorkAt = MANIM_SYSTEM_PROMPT.indexOf("## How you work");
+    const craftAt = PROMPT.indexOf(MANIM_CRAFT);
+    const lessonsAt = PROMPT.indexOf(CRAFT_LESSONS);
+    const howYouWorkAt = PROMPT.indexOf("## How you work");
     expect(craftAt).toBeGreaterThan(-1);
     expect(lessonsAt).toBeGreaterThan(craftAt);
     expect(howYouWorkAt).toBeGreaterThan(lessonsAt);
+  });
+
+  it("threads the user's narration voice into the verbatim speech-service call", () => {
+    expect(PROMPT).toContain('voice_id="voice-test-1"');
+    // No stray hardcoded voice survives the interpolation.
+    expect(PROMPT).not.toContain("Xb7hH8MSUJpSbSDYk0k2");
   });
 });
 

--- a/packages/agent/src/prompts/index.ts
+++ b/packages/agent/src/prompts/index.ts
@@ -1,10 +1,18 @@
-/** The agent's persona and operating instructions. The always-on Manim craft
+/** The agent's persona and operating instructions, built per turn from the
+ * user's generation settings (narration voice). The always-on Manim craft
  * rules live in ./manim-craft. */
 
 import { CRAFT_LESSONS } from "./craft-lessons.ts";
 import { MANIM_CRAFT } from "./manim-craft.ts";
 
-export const MANIM_SYSTEM_PROMPT = `You are animus, an expert assistant that creates mathematically precise, research-grounded explainer videos built with Manim (the Python animation engine). You work with the user in chat: shape the idea together, then write and render the Manim code yourself in a per-conversation cloud sandbox. The sandbox has Manim, ffmpeg and LaTeX (TeX Live) installed.
+export function buildManimSystemPrompt({
+  voiceId,
+}: {
+  /** The ElevenLabs voice the narration synthesizes with — the user's settings
+   * choice, threaded into the verbatim set_speech_service instruction. */
+  voiceId: string;
+}): string {
+  return `You are animus, an expert assistant that creates mathematically precise, research-grounded explainer videos built with Manim (the Python animation engine). You work with the user in chat: shape the idea together, then write and render the Manim code yourself in a per-conversation cloud sandbox. The sandbox has Manim, ffmpeg and LaTeX (TeX Live) installed.
 
 How a video gets made: **plan** it with the user (and research anything you're not certain of) → **produce** it yourself in the sandbox, iterating until clean → **deliver** it with one final render. You own the code end to end; the user steers the conversation and never sees or runs code themselves.
 
@@ -30,7 +38,7 @@ Production happens in the sandbox. You have real tools — use them, do not just
 ## Narration
 
 Every video is narrated. Write the scene as a manim-voiceover VoiceoverScene and let the narration drive timing — do not manage durations by hand:
-- Subclass VoiceoverScene (\`from manim_voiceover import VoiceoverScene\`), not Scene. As the FIRST line of construct, set the speech service with EXACTLY this call: \`self.set_speech_service(ElevenLabsService(voice_id="Xb7hH8MSUJpSbSDYk0k2", model="eleven_multilingual_v2", transcription_model=None))\` (\`from manim_voiceover.services.elevenlabs import ElevenLabsService\`). Always select the voice by \`voice_id\` — NEVER \`voice_name\`, which requires an exact match against the account's full display names ("Sarah - Mature, Reassuring, Confident") and fails for short names. Use it verbatim — the bundled skill shows \`model_id=\` and omits \`transcription_model\`, but our installed version takes \`model=\`, and \`transcription_model=None\` is REQUIRED (otherwise it tries to load Whisper and prompts for input, which crashes the non-interactive render). The API key is already in the environment — NEVER put a key in the code, and do not try to patch the service or install extra packages.
+- Subclass VoiceoverScene (\`from manim_voiceover import VoiceoverScene\`), not Scene. As the FIRST line of construct, set the speech service with EXACTLY this call: \`self.set_speech_service(ElevenLabsService(voice_id="${voiceId}", model="eleven_multilingual_v2", transcription_model=None))\` (\`from manim_voiceover.services.elevenlabs import ElevenLabsService\`). Always select the voice by \`voice_id\` — NEVER \`voice_name\`, which requires an exact match against the account's full display names ("Sarah - Mature, Reassuring, Confident") and fails for short names. Use it verbatim — the bundled skill shows \`model_id=\` and omits \`transcription_model\`, but our installed version takes \`model=\`, and \`transcription_model=None\` is REQUIRED (otherwise it tries to load Whisper and prompts for input, which crashes the non-interactive render). The API key is already in the environment — NEVER put a key in the code, and do not try to patch the service or install extra packages.
 - Wrap every beat in a voiceover block and sync the animation to the speech: \`with self.voiceover(text="...") as tracker:\` then \`self.play(..., run_time=tracker.duration)\` (or \`self.wait(tracker.duration)\` for a still moment). The scene's length is the sum of its narration.
 - Write the narration as you write the code: clear, spoken-language sentences describing what the viewer sees, one beat at a time. Show then tell — reveal the visual as (or just before) the words describe it. This script is the spine of the video, so make it genuinely explain the topic.
 - Do NOT add background music in the scene — animus mixes a music bed under your narration automatically after rendering. Just write the narration.
@@ -56,3 +64,4 @@ Say what you notice. If something looks wrong — the request is infeasible as s
 ## Communication
 
 Be clear and concise. Lead with the idea, then the detail. Use plain language; reserve math notation for when it adds precision.`;
+}

--- a/packages/agent/src/tools/index.ts
+++ b/packages/agent/src/tools/index.ts
@@ -31,6 +31,8 @@ interface ToolDependencies {
     conversationId: string;
     saveVideo: SaveVideo;
     backgroundMusicUrl: BackgroundMusicUrl;
+    backgroundMusic: boolean;
+    musicTrackId: string;
     elevenLabsApiKey: string;
     meter: TurnMeter;
   };

--- a/packages/agent/src/tools/manim.ts
+++ b/packages/agent/src/tools/manim.ts
@@ -43,7 +43,8 @@ export type SaveVideo = (input: {
 /** A presigned URL the sandbox downloads the background track from (straight
  * from R2, no byte round-trip through the API). Implemented by the API so the
  * track can change without a sandbox rebuild. */
-export type BackgroundMusicUrl = () => Promise<string>;
+/** Presigns the R2 track for the user's chosen music track id. */
+export type BackgroundMusicUrl = (trackId: string) => Promise<string>;
 
 /** A mutable per-turn accumulator the API owns. `renderScene` adds the narration
  * characters it synthesizes so the API can meter TTS cost after the turn. */
@@ -102,9 +103,9 @@ function outputPath(
 async function muxBackgroundMusic(
   sandbox: Sandbox,
   masterPath: string,
-  backgroundMusicUrl: BackgroundMusicUrl
+  getMusicUrl: () => Promise<string>
 ): Promise<{ deliverPath: string; note?: string }> {
-  const url = await backgroundMusicUrl();
+  const url = await getMusicUrl();
   const finalPath = masterPath.replace(MP4_SUFFIX, ".music.mp4");
   // Download then mix in one shell step; the URL rides in the env (not the
   // command string) so its signature query params can't break quoting. A missing
@@ -135,6 +136,10 @@ export function createManimTools(deps: {
   conversationId: string;
   saveVideo: SaveVideo;
   backgroundMusicUrl: BackgroundMusicUrl;
+  /** The user's generation settings: whether to mix a music bed at all, and
+   * which catalog track to use when so. */
+  backgroundMusic: boolean;
+  musicTrackId: string;
   /** The effective ElevenLabs key for this turn (the user's own when they've
    * brought one, otherwise ours). Injected into the render command so narration
    * synthesizes against the right account. */
@@ -147,6 +152,8 @@ export function createManimTools(deps: {
     conversationId,
     saveVideo,
     backgroundMusicUrl,
+    backgroundMusic,
+    musicTrackId,
     elevenLabsApiKey,
     meter,
   } = deps;
@@ -275,11 +282,13 @@ export function createManimTools(deps: {
         }
 
         const masterPath = outputPath(output, file, scene, quality);
-        const { deliverPath, note } = await muxBackgroundMusic(
-          sandbox,
-          masterPath,
-          backgroundMusicUrl
-        );
+        // The music bed honors the user's settings: skipped entirely when
+        // background music is off, otherwise mixed from their chosen track.
+        const { deliverPath, note } = backgroundMusic
+          ? await muxBackgroundMusic(sandbox, masterPath, () =>
+              backgroundMusicUrl(musicTrackId)
+            )
+          : { deliverPath: masterPath, note: undefined };
         const deliveredLogs = note ? `${logs}\n\n${note}` : logs;
         try {
           const buffer = await sandbox.fs.downloadFile(deliverPath);


### PR DESCRIPTION
PR 3 of the stack (base: `fix/turn-lifecycle` ← `fix/settings-nullable` ← main; merge in order).

The generation settings were decorative: `chat.ts` never read them, the prompt mandated `voice_id="Xb7hH8MSUJpSbSDYk0k2"` verbatim, and `muxBackgroundMusic` ran unconditionally with one fixed R2 key. Now:

- **Voice** — `MANIM_SYSTEM_PROMPT` became `buildManimSystemPrompt({ voiceId })`, built per turn with the user's settings voice (domain defaults when they never saved any).
- **Music toggle** — `renderScene` skips the download/ffmpeg step entirely when background music is off; the silent master is delivered.
- **Music track** — `backgroundMusicUrl(trackId)` resolves through a catalog map in `media.ts`. Honest caveat: every id currently maps to the one licensed track in the bucket (`The_Merchants_Of_Death.mp3`) — the plumbing is real, but picking "upbeat" sounds identical until the curated tracks are chosen and uploaded (todo: music library). Swap map entries as they land.
- Threading: chat route → `createManimAgent` (`voiceId`/`backgroundMusic`/`musicTrackId`) → prompt + manim tools.

Not included, deliberately: **theme** (the craft rules hardcode the dark palette — wiring light needs its own craft guidance, and shipping it half-wired would produce broken-looking videos) and **font** (needs fonts in the sandbox snapshot; both are already marked/locked in the UI or listed for the 0.7 snapshot bump).

4 new/updated test areas (361 total): voice interpolation into the prompt (and no stray hardcoded voice), mux skipped + no presign when music is off, track id passed to the presigner + unknown-id fallback, chat route passes settings into the agent.